### PR TITLE
Dev v.2.4.0 3.0.0+vm.2

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,10 @@
-## v2.4.0-3.0.0+vm.2 - NVIDIA weather effects and fast clouds hotfix
+## v2.4.0-3.0.0+vm.2 - NVIDIA weather effects, SSAO smoothing, and rendering fixes
 
 **Hotfix** — weather effects (rain, snow, particles) now render correctly in front of LODs on all GPUs. Fast clouds no longer render on top of LODs. Previously, the Phase 2 composite was overwriting weather pixels with LOD colors on NVIDIA and potentially other non-MoltenVK drivers.
+
+- **SSAO smoothing** — enabled the bilateral Gaussian blur on SSAO output. Previously the blur was disabled (radius 0), causing visibly grainy/noisy ambient occlusion.
+- **Z-fighting fix (NONE mode)** — added small depth bias to LOD depth output in NONE fade mode, preventing z-fighting at the MC/LOD overlap boundary.
+- **High-altitude LOD gap fix** — LOD clip distance now uses 3D distance instead of XZ-only. Previously, flying high and looking down created a visible gap between MC terrain and LODs because the cylindrical XZ clip didn't match MC's spherical render distance.
 
 
 ## v2.4.0-3.0.0+vm.1

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,11 +1,11 @@
-## v2.4.0-3.0.0+vm.2
+## v2.4.0-3.0.0+vm.2 - NVIDIA weather effects and fast clouds hotfix
 
-**Hotfix** — weather effects (rain, snow, particles) now render correctly in front of LODs on all GPUs. Previously, the Phase 2 composite was overwriting weather pixels with LOD colors on NVIDIA and potentially other non-MoltenVK drivers.
+**Hotfix** — weather effects (rain, snow, particles) now render correctly in front of LODs on all GPUs. Fast clouds no longer render on top of LODs. Previously, the Phase 2 composite was overwriting weather pixels with LOD colors on NVIDIA and potentially other non-MoltenVK drivers.
 
 
 ## v2.4.0-3.0.0+vm.1
 
-**Clouds, weather, and DH 3.0 support.** Clouds now render correctly behind and in front of LOD terrain. Weather effects (rain, snow) are no longer hidden behind LODs. Compatible with both DH 2.4.x and 3.0.x (nightly) from a single jar.
+**Clouds, weather, and DH 3.0 support.** Clouds now render correctly behind and in front of LOD terrain. Weather effects (rain, snow) are no longer hidden behind LODs on any GPU. Compatible with both DH 2.4.x and 3.0.x (nightly) from a single jar.
 
 ### What's New
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,6 +2,7 @@
 org.gradle.jvmargs=-Xmx4096M
 org.gradle.parallel=true
 org.gradle.caching=true
+org.gradle.java.home=/Library/Java/JavaVirtualMachines/zulu-21.jdk/Contents/Home
 
 # Mod Info
 mod_name=DistantHorizons-VulkanMod

--- a/vulkan/src/main/java/com/braffolk/dhvulkan/api/VkRenderApiDefinition.java
+++ b/vulkan/src/main/java/com/braffolk/dhvulkan/api/VkRenderApiDefinition.java
@@ -113,6 +113,17 @@ public class VkRenderApiDefinition extends AbstractDhRenderApiDefinition {
             backend.beginFrame();
             backend.fillUniforms(this.cachedUniforms);
             this.frameActive = true;
+
+            // Set up the late composite hook for SINGLE/DOUBLE Phase 2.
+            // MixinLevelRenderer fires at renderLevel @RETURN → Compat.runLateCompositeHook().
+            // In DH 2.4, this hook is set by MixinLodRenderer. In DH 3.0, the 2.4 mixin
+            // doesn't fire, so we set it here to ensure Phase 2 + clouds work in both paths.
+            // Note: no frameActive guard — runRenderPassCleanup sets it false before this fires.
+            // VulkanRenderEngine.lateComposite() has its own frameReady guard.
+            com.braffolk.dhvulkan.compat.Compat.setLateCompositeHook(() -> {
+                toUniforms(renderParams, this.cachedUniforms);
+                backend.lateComposite(this.cachedUniforms);
+            });
         }
 
         @Override
@@ -162,13 +173,22 @@ public class VkRenderApiDefinition extends AbstractDhRenderApiDefinition {
 
         private static void resolveFields() {
             if (reflectionResolved) return;
+            // DH 3.0 renamed vbos → vboOpaqueWrappers, vbosTransparent → vboTransparentWrappers
+            // Try new names first, fall back to old for DH 2.4 compat
             try {
-                vbosField = LodBufferContainer.class.getDeclaredField("vbos");
+                vbosField = LodBufferContainer.class.getDeclaredField("vboOpaqueWrappers");
                 vbosField.setAccessible(true);
-                vbosTransparentField = LodBufferContainer.class.getDeclaredField("vbosTransparent");
+                vbosTransparentField = LodBufferContainer.class.getDeclaredField("vboTransparentWrappers");
                 vbosTransparentField.setAccessible(true);
             } catch (NoSuchFieldException e) {
-                throw new RuntimeException("[DH-VulkanMod] LodBufferContainer missing vbos field", e);
+                try {
+                    vbosField = LodBufferContainer.class.getDeclaredField("vbos");
+                    vbosField.setAccessible(true);
+                    vbosTransparentField = LodBufferContainer.class.getDeclaredField("vbosTransparent");
+                    vbosTransparentField.setAccessible(true);
+                } catch (NoSuchFieldException e2) {
+                    throw new RuntimeException("[DH-VulkanMod] LodBufferContainer missing vbos field (tried both 2.4 and 3.0 names)", e2);
+                }
             }
             reflectionResolved = true;
         }

--- a/vulkan/src/main/java/com/braffolk/dhvulkan/api/VkRenderApiDefinition.java
+++ b/vulkan/src/main/java/com/braffolk/dhvulkan/api/VkRenderApiDefinition.java
@@ -161,8 +161,9 @@ public class VkRenderApiDefinition extends AbstractDhRenderApiDefinition {
         // Cached to avoid per-container allocation in the render loop
         private final Vec3f reusableModelPos = new Vec3f(0, 0, 0);
 
-        // Cached reflection fields — type of vbos differs between DH versions
-        // (GLVertexBuffer[] in 2.4 vs IVertexBufferWrapper[] in 3.0)
+        // Cached reflection fields for VBO arrays in LodBufferContainer.
+        // DH 3.0: vboOpaqueWrappers / vboTransparentWrappers
+        // [DH 2.4 COMPAT]: vbos / vbosTransparent
         private static java.lang.reflect.Field vbosField;
         private static java.lang.reflect.Field vbosTransparentField;
         private static boolean reflectionResolved = false;
@@ -173,14 +174,14 @@ public class VkRenderApiDefinition extends AbstractDhRenderApiDefinition {
 
         private static void resolveFields() {
             if (reflectionResolved) return;
-            // DH 3.0 renamed vbos → vboOpaqueWrappers, vbosTransparent → vboTransparentWrappers
-            // Try new names first, fall back to old for DH 2.4 compat
+            // DH 3.0 field names (preferred)
             try {
                 vbosField = LodBufferContainer.class.getDeclaredField("vboOpaqueWrappers");
                 vbosField.setAccessible(true);
                 vbosTransparentField = LodBufferContainer.class.getDeclaredField("vboTransparentWrappers");
                 vbosTransparentField.setAccessible(true);
             } catch (NoSuchFieldException e) {
+                // [DH 2.4 COMPAT] Old field names — remove this catch block when dropping 2.4
                 try {
                     vbosField = LodBufferContainer.class.getDeclaredField("vbos");
                     vbosField.setAccessible(true);

--- a/vulkan/src/main/java/com/braffolk/dhvulkan/api/VkVertexBufferWrapper.java
+++ b/vulkan/src/main/java/com/braffolk/dhvulkan/api/VkVertexBufferWrapper.java
@@ -31,6 +31,20 @@ public class VkVertexBufferWrapper implements IVertexBufferWrapper {
 
     @Override
     public void upload(ByteBuffer buffer, int vertexCount) {
+        uploadVertexBufferImpl(buffer, vertexCount);
+    }
+
+    // DH 3.0 renamed upload() to uploadVertexBuffer() and added uploadIndexBuffer()
+    // Both must exist for cross-version compatibility
+    public void uploadVertexBuffer(ByteBuffer buffer, int vertexCount) {
+        uploadVertexBufferImpl(buffer, vertexCount);
+    }
+
+    public void uploadIndexBuffer(ByteBuffer buffer, int vertexCount) {
+        // No-op — we use a shared IBO (useSingleIbo() = true in VkRenderApiDefinition)
+    }
+
+    private void uploadVertexBufferImpl(ByteBuffer buffer, int vertexCount) {
         if (this.vertexData == null) {
             this.vertexData = new VkVertexData(id);
         }

--- a/vulkan/src/main/java/com/braffolk/dhvulkan/api/VkVertexBufferWrapper.java
+++ b/vulkan/src/main/java/com/braffolk/dhvulkan/api/VkVertexBufferWrapper.java
@@ -8,10 +8,14 @@ import org.lwjgl.system.MemoryUtil;
 import java.nio.ByteBuffer;
 
 /**
- * Vulkan implementation of DH 3.0's VBO wrapper.
- * DH creates one of these per LOD section via the factory method
- * and calls upload() to push vertex data. We store the data as
- * VkVertexData which our VulkanBackend can draw.
+ * Vulkan implementation of DH's VBO wrapper (IVertexBufferWrapper).
+ * DH creates one per LOD section and calls uploadVertexBuffer() (DH 3.0)
+ * or upload() (DH 2.4) to push vertex data.
+ *
+ * Cross-version notes:
+ *   - upload()             → [DH 2.4 COMPAT] old method name, delegates to impl
+ *   - uploadVertexBuffer() → DH 3.0 method name
+ *   - uploadIndexBuffer()  → DH 3.0 no-op (we use shared IBO)
  */
 public class VkVertexBufferWrapper implements IVertexBufferWrapper {
 
@@ -29,19 +33,20 @@ public class VkVertexBufferWrapper implements IVertexBufferWrapper {
         this.id = nextId++;
     }
 
+    // [DH 2.4 COMPAT] DH 2.4 calls upload(); DH 3.0 calls uploadVertexBuffer().
+    // Remove this method when dropping DH 2.4 support.
     @Override
     public void upload(ByteBuffer buffer, int vertexCount) {
         uploadVertexBufferImpl(buffer, vertexCount);
     }
 
-    // DH 3.0 renamed upload() to uploadVertexBuffer() and added uploadIndexBuffer()
-    // Both must exist for cross-version compatibility
+    // DH 3.0 interface methods
     public void uploadVertexBuffer(ByteBuffer buffer, int vertexCount) {
         uploadVertexBufferImpl(buffer, vertexCount);
     }
 
     public void uploadIndexBuffer(ByteBuffer buffer, int vertexCount) {
-        // No-op — we use a shared IBO (useSingleIbo() = true in VkRenderApiDefinition)
+        // No-op — we use a shared IBO (useSingleIbo() returns true)
     }
 
     private void uploadVertexBufferImpl(ByteBuffer buffer, int vertexCount) {

--- a/vulkan/src/main/java/com/braffolk/dhvulkan/core/VulkanCloudRenderer.java
+++ b/vulkan/src/main/java/com/braffolk/dhvulkan/core/VulkanCloudRenderer.java
@@ -36,7 +36,8 @@ public class VulkanCloudRenderer {
 
     private static final Logger LOGGER = LogManager.getLogger("DH-VulkanMod");
 
-    // Lazy-initialized — SingletonInjector may not have it registered at class load time
+    // Lazy-initialized — SingletonInjector may not have it registered at class load
+    // time
     private static IMinecraftRenderWrapper MC_RENDER;
     private static boolean mcRenderResolved = false;
 
@@ -103,26 +104,33 @@ public class VulkanCloudRenderer {
         if (--this.configRefreshCounter <= 0) {
             this.configRefreshCounter = CONFIG_REFRESH_INTERVAL;
             try {
-                this.cloudRenderingEnabled = Config.Client.Advanced.Graphics.GenericRendering.enableCloudRendering.get();
+                this.cloudRenderingEnabled = Config.Client.Advanced.Graphics.GenericRendering.enableCloudRendering
+                        .get();
             } catch (Exception e) {
                 this.cloudRenderingEnabled = true;
             }
         }
-        if (!this.cloudRenderingEnabled) return;
+        if (!this.cloudRenderingEnabled)
+            return;
 
         Minecraft mc = Minecraft.getInstance();
         ClientLevel level = mc.level;
-        if (level == null) return;
+        if (level == null)
+            return;
 
         int cloudHeight = Compat.getCloudHeight(level);
-        if (cloudHeight < 0) return;
+        if (cloudHeight < 0)
+            return;
 
-        if (!this.reflectionResolved) resolveReflection();
-        if (this.reflectionFailed) return;
+        if (!this.reflectionResolved)
+            resolveReflection();
+        if (this.reflectionFailed)
+            return;
 
         if (!this.textureLoaded) {
             loadCloudTexture();
-            if (!this.textureLoaded) return;
+            if (!this.textureLoaded)
+                return;
         }
 
         try {
@@ -133,12 +141,13 @@ public class VulkanCloudRenderer {
     }
 
     private void renderClouds(ClientLevel level, Minecraft mc, int cloudHeight,
-                              float partialTicks, Mat4f mcProjection, Mat4f mcModelView) throws Throwable {
+            float partialTicks, Mat4f mcProjection, Mat4f mcModelView) throws Throwable {
         if (!mcRenderResolved) {
             MC_RENDER = SingletonInjector.INSTANCE.get(IMinecraftRenderWrapper.class);
             mcRenderResolved = true;
         }
-        if (MC_RENDER == null) return;
+        if (MC_RENDER == null)
+            return;
         var camPos = MC_RENDER.getCameraExactPosition();
 
         int ticks = (int) (level.getGameTime() % Integer.MAX_VALUE);
@@ -151,9 +160,12 @@ public class VulkanCloudRenderer {
         int centerCellZ = (int) Math.floor(centerZ / CELL_WIDTH);
 
         byte yState;
-        if (centerY < -4.0f) yState = Y_BELOW_CLOUDS;
-        else if (centerY > 0.0f) yState = Y_ABOVE_CLOUDS;
-        else yState = Y_INSIDE_CLOUDS;
+        if (centerY < -4.0f)
+            yState = Y_BELOW_CLOUDS;
+        else if (centerY > 0.0f)
+            yState = Y_ABOVE_CLOUDS;
+        else
+            yState = Y_INSIDE_CLOUDS;
 
         CloudStatus cloudsType = mc.options.getCloudsType();
 
@@ -170,23 +182,29 @@ public class VulkanCloudRenderer {
 
         if (this.needsRebuild) {
             this.needsRebuild = false;
-            if (this.cloudVBO != null) this.vboCloseHandle.invoke(this.cloudVBO);
+            if (this.cloudVBO != null)
+                this.vboCloseHandle.invoke(this.cloudVBO);
 
             Object cloudsMesh = buildCloudMesh(centerCellX, centerCellZ, centerY, cloudsType);
-            if (cloudsMesh == null) { this.cloudVBO = null; return; }
+            if (cloudsMesh == null) {
+                this.cloudVBO = null;
+                return;
+            }
 
             this.cloudVBO = this.vboConstructorHandle.invoke(true);
             this.vboUploadHandle.invoke(this.cloudVBO, cloudsMesh);
         }
 
-        if (this.cloudVBO == null) return;
+        if (this.cloudVBO == null)
+            return;
 
         // --- Rendering ---
         float xTranslation = (float) (centerX - (centerCellX * CELL_WIDTH));
         float yTranslation = (float) centerY;
         float zTranslation = (float) (centerZ - (centerCellZ * CELL_WIDTH));
 
-        // Restore MC's projection — critical for depth testing against combined depth buffer.
+        // Restore MC's projection — critical for depth testing against combined depth
+        // buffer.
         copyToJoml(mcProjection, this.reusableJomlProj);
         VRenderSystem.applyProjectionMatrix(this.reusableJomlProj);
 
@@ -216,6 +234,8 @@ public class VulkanCloudRenderer {
                     org.lwjgl.opengl.GL11.GL_ZERO);
             VRenderSystem.enableDepthTest();
             VRenderSystem.depthFunc(org.lwjgl.opengl.GL11.GL_LEQUAL);
+            // Clouds depth-TEST (hide behind terrain/LODs) but do NOT depth-WRITE.
+            // This prevents cloud depth from blocking weather/particles rendered later.
             VRenderSystem.depthMask = true;
             VRenderSystem.setPolygonModeGL(org.lwjgl.opengl.GL11.GL_FILL);
             VRenderSystem.setPrimitiveTopologyGL(org.lwjgl.opengl.GL11.GL_TRIANGLES);
@@ -248,11 +268,11 @@ public class VulkanCloudRenderer {
     }
 
     // ========================= //
-    // Cloud mesh generation     //
+    // Cloud mesh generation //
     // ========================= //
 
     private Object buildCloudMesh(int centerCellX, int centerCellZ,
-                                  double cloudY, CloudStatus cloudsType) {
+            double cloudY, CloudStatus cloudsType) {
         final float upFaceBrightness = 1.0f;
         final float xDirBrightness = 0.9f;
         final float downFaceBrightness = 0.7f;
@@ -353,7 +373,7 @@ public class VulkanCloudRenderer {
     }
 
     // ========================= //
-    // Cloud texture loading     //
+    // Cloud texture loading //
     // ========================= //
 
     private void loadCloudTexture() {
@@ -383,13 +403,18 @@ public class VulkanCloudRenderer {
             for (int x = 0; x < this.cloudGridWidth; x++) {
                 int idx = z * this.cloudGridWidth + x;
                 int pixel = this.cloudPixels[idx];
-                if (!hasAlpha(pixel)) continue;
+                if (!hasAlpha(pixel))
+                    continue;
 
                 byte faces = (byte) (DIR_NEG_Y_BIT | DIR_POS_Y_BIT);
-                if (pixel != getTexelWrapped(x - 1, z)) faces |= DIR_NEG_X_BIT;
-                if (pixel != getTexelWrapped(x + 1, z)) faces |= DIR_POS_X_BIT;
-                if (pixel != getTexelWrapped(x, z - 1)) faces |= DIR_NEG_Z_BIT;
-                if (pixel != getTexelWrapped(x, z + 1)) faces |= DIR_POS_Z_BIT;
+                if (pixel != getTexelWrapped(x - 1, z))
+                    faces |= DIR_NEG_X_BIT;
+                if (pixel != getTexelWrapped(x + 1, z))
+                    faces |= DIR_POS_X_BIT;
+                if (pixel != getTexelWrapped(x, z - 1))
+                    faces |= DIR_NEG_Z_BIT;
+                if (pixel != getTexelWrapped(x, z + 1))
+                    faces |= DIR_POS_Z_BIT;
                 renderFaces[idx] = faces;
             }
         }
@@ -421,7 +446,7 @@ public class VulkanCloudRenderer {
     }
 
     // ========================= //
-    // Reflection resolution     //
+    // Reflection resolution //
     // ========================= //
 
     private void resolveReflection() {
@@ -463,7 +488,8 @@ public class VulkanCloudRenderer {
 
             LOGGER.info("[DH-VulkanMod] Cloud renderer MethodHandles resolved (VM 0.6).");
         } catch (Exception e) {
-            LOGGER.info("[DH-VulkanMod] VM 0.6 cloud API not available, custom cloud renderer disabled. ({})", e.getMessage());
+            LOGGER.info("[DH-VulkanMod] VM 0.6 cloud API not available, custom cloud renderer disabled. ({})",
+                    e.getMessage());
             this.reflectionFailed = true;
         }
     }
@@ -471,7 +497,10 @@ public class VulkanCloudRenderer {
     /** Reload cloud texture (called on resource reload). */
     public void resetBuffer() {
         if (this.cloudVBO != null) {
-            try { this.vboCloseHandle.invoke(this.cloudVBO); } catch (Throwable ignored) {}
+            try {
+                this.vboCloseHandle.invoke(this.cloudVBO);
+            } catch (Throwable ignored) {
+            }
             this.cloudVBO = null;
         }
         this.needsRebuild = true;

--- a/vulkan/src/main/java/com/braffolk/dhvulkan/core/VulkanRenderEngine.java
+++ b/vulkan/src/main/java/com/braffolk/dhvulkan/core/VulkanRenderEngine.java
@@ -494,18 +494,20 @@ public class VulkanRenderEngine implements VulkanBackend {
             com.seibel.distanthorizons.api.enums.config.EDhApiMcRenderingFadeMode fadeMode = DhConfigHelper.vanillaFadeMode();
             if (fadeMode == com.seibel.distanthorizons.api.enums.config.EDhApiMcRenderingFadeMode.NONE) {
                 // NONE: only composite, no Phase 2b re-composite.
-                // Render clouds BEFORE composite so LODs draw on top (no depth available in NONE mode).
-                if (this.cloudRenderer.isAvailable()) {
-                    this.profiler.begin(DhFrameProfiler.PHASE_CLOUDS);
-                    this.cloudRenderer.renderIfEnabled(uniforms.partialTicks, uniforms.mcProjectionMatrix, uniforms.dhModelViewMatrix);
-                    this.profiler.end(DhFrameProfiler.PHASE_CLOUDS);
-                }
                 this.profiler.begin(DhFrameProfiler.PHASE_COMPOSITE);
                 VulkanImage mcDepthForComposite = DhVulkanConfig.get().vulkanRenderMode == 6 && this.depthReaderPipeline != null
                         ? this.depthReaderPipeline.getCachedDepthTexture()
                         : null;
                 this.runComposite(uniforms, mcDepthForComposite);
                 this.profiler.end(DhFrameProfiler.PHASE_COMPOSITE);
+
+                // Render clouds AFTER composite so they accurately depth test against MC terrain and DH LODs.
+                // (In NONE mode, Phase 1 composite writes true LOD depth).
+                if (this.cloudRenderer.isAvailable()) {
+                    this.profiler.begin(DhFrameProfiler.PHASE_CLOUDS);
+                    this.cloudRenderer.renderIfEnabled(uniforms.partialTicks, uniforms.mcProjectionMatrix, uniforms.dhModelViewMatrix);
+                    this.profiler.end(DhFrameProfiler.PHASE_CLOUDS);
+                }
             } else if (DhVulkanConfig.get().vulkanRenderMode != 6) {
                 // SINGLE/DOUBLE normal: draw LOD colors with depth=1.0 (shader handles it).
                 this.profiler.begin(DhFrameProfiler.PHASE_COMPOSITE);
@@ -694,12 +696,13 @@ public class VulkanRenderEngine implements VulkanBackend {
             float fadeStartDist = dhNearClipDistance * 1.5f;
             float fadeEndDist = dhNearClipDistance * 1.9f;
 
+            boolean isNoneMode = DhConfigHelper.vanillaFadeMode() == com.seibel.distanthorizons.api.enums.config.EDhApiMcRenderingFadeMode.NONE;
             this.compositePipeline.render(
                     this.dhFramebuffer.getFramebuffer().getColorAttachment(),
                     this.dhFramebuffer.getFramebuffer().getDepthAttachment(),
                     ssaoTex, fogTex,
                     mcDepthTexture,
-                    debugMode, this.tempInvProjArray, this.tempMcProjArray,
+                    debugMode, isNoneMode, this.tempInvProjArray, this.tempMcProjArray,
                     this.tempInvMcMvmProjArray, fadeStartDist, fadeEndDist);
         }
     }

--- a/vulkan/src/main/java/com/braffolk/dhvulkan/core/VulkanRenderEngine.java
+++ b/vulkan/src/main/java/com/braffolk/dhvulkan/core/VulkanRenderEngine.java
@@ -588,15 +588,17 @@ public class VulkanRenderEngine implements VulkanBackend {
             }
 
             Compat.rebindMainTarget();
-            this.runComposite(uniforms, mcDepthR32F);
 
-            // VM 0.6: clouds render in MC's render pass, depth-testing against combined depth.
-            // VM 0.4.2: clouds were already rendered in endFrame() via DH framebuffer.
+            // Clouds render BEFORE composite so the composite draws LODs on top (GL_ALWAYS).
+            // Phase 2's discard (where mcDepth >= 1.0) preserves clouds at open-sky LOD pixels.
+            // This matches NONE mode's order in endFrame().
             if (this.cloudRenderer.isAvailable()) {
                 this.profiler.begin(DhFrameProfiler.PHASE_CLOUDS);
                 this.cloudRenderer.renderIfEnabled(uniforms.partialTicks, uniforms.mcProjectionMatrix, uniforms.dhModelViewMatrix);
                 this.profiler.end(DhFrameProfiler.PHASE_CLOUDS);
             }
+
+            this.runComposite(uniforms, mcDepthR32F);
         } catch (Exception e) {
             LOGGER.error("[DH-Vulkan] Phase 2 composite error", e);
             try {

--- a/vulkan/src/main/java/com/braffolk/dhvulkan/core/VulkanRenderEngine.java
+++ b/vulkan/src/main/java/com/braffolk/dhvulkan/core/VulkanRenderEngine.java
@@ -507,7 +507,14 @@ public class VulkanRenderEngine implements VulkanBackend {
                 this.runComposite(uniforms, mcDepthForComposite);
                 this.profiler.end(DhFrameProfiler.PHASE_COMPOSITE);
             } else if (DhVulkanConfig.get().vulkanRenderMode != 6) {
-                // SINGLE/DOUBLE normal: draw LOD colors with depth=1.0 (shader handles it).
+                // SINGLE/DOUBLE normal: render clouds first, then Phase 1 composite.
+                // Clouds render BEFORE composite so LODs draw on top via alpha blend,
+                // naturally occluding clouds behind tall LOD mountains.
+                if (this.cloudRenderer.isAvailable()) {
+                    this.profiler.begin(DhFrameProfiler.PHASE_CLOUDS);
+                    this.cloudRenderer.renderIfEnabled(uniforms.partialTicks, uniforms.mcProjectionMatrix, uniforms.dhModelViewMatrix);
+                    this.profiler.end(DhFrameProfiler.PHASE_CLOUDS);
+                }
                 this.profiler.begin(DhFrameProfiler.PHASE_COMPOSITE);
                 this.runComposite(uniforms, null);
                 this.profiler.end(DhFrameProfiler.PHASE_COMPOSITE);
@@ -535,52 +542,31 @@ public class VulkanRenderEngine implements VulkanBackend {
 
     @Override
     public void deferredComposite(RenderUniforms uniforms) {
-        // Fallback: called from addCloudsPass @HEAD if that hook fires.
-        // On VulkanMod 0.6.1, addCloudsPass does NOT exist — all work is done
-        // in lateComposite (renderLevel @RETURN) instead.
-        // This is kept for compatibility with VM versions that DO call addCloudsPass.
-        if (!this.frameReady) return;
-        // If this fires, skip lateComposite's work by marking phase2 done.
-        this.phase2Done = true;
-        doPhase2(uniforms);
+        // Not used — addCloudsPass/renderClouds mixin hooks don't fire in VulkanMod
+        // (MC 1.21.11 Frame Graph prevents method-level injection).
+        // Phase 2 runs exclusively via lateComposite.
     }
 
     /**
-     * Called from renderLevel @RETURN — AFTER terrain, weather, everything.
-     * 
-     * On VulkanMod 0.6.1, this is the ONLY hook that fires (addCloudsPass doesn't exist).
-     * Does: read MC depth, re-composite LODs with depth comparison, render clouds.
+     * Phase 2: re-composite LODs at renderLevel @RETURN (after terrain + weather).
+     * Reads MC depth and re-composites LODs with per-pixel depth comparison.
+     * Open-sky LOD pixels are discarded (shader) to preserve weather.
+     * Clouds are NOT rendered here — they render in endFrame before Phase 1.
      */
     @Override
     public void lateComposite(RenderUniforms uniforms) {
-        if (this.phase2Done) {
-            this.phase2Done = false;
-            return; // Already handled by deferredComposite
-        }
+        if (!this.frameReady) return;
 
         com.seibel.distanthorizons.api.enums.config.EDhApiMcRenderingFadeMode fadeMode = DhConfigHelper.vanillaFadeMode();
         if (fadeMode == com.seibel.distanthorizons.api.enums.config.EDhApiMcRenderingFadeMode.NONE) {
-            // NONE: clouds already rendered in endFrame before composite. Nothing to do.
             return;
         }
 
-        if (!this.frameReady) return;
-        doPhase2(uniforms);
-    }
-
-    private boolean phase2Done = false;
-
-    /**
-     * Phase 2: read MC depth, re-composite LODs with depth comparison, render clouds.
-     * Called from whichever hook fires first (deferredComposite or lateComposite).
-     */
-    private void doPhase2(RenderUniforms uniforms) {
         this.profiler.begin(DhFrameProfiler.PHASE_PHASE2);
         try {
             VulkanImage mcDepth = Compat.getSwapChainDepthAttachment();
             Renderer.getInstance().endRenderPass();
 
-            // Read MC depth into sampleable R32F
             VulkanImage mcDepthR32F = null;
             if (this.depthReaderPipeline != null) {
                 mcDepthR32F = this.depthReaderPipeline.readDepth(mcDepth);
@@ -588,15 +574,6 @@ public class VulkanRenderEngine implements VulkanBackend {
             }
 
             Compat.rebindMainTarget();
-
-            // Clouds render BEFORE composite so the composite draws LODs on top (GL_ALWAYS).
-            // Phase 2's discard (where mcDepth >= 1.0) preserves clouds at open-sky LOD pixels.
-            // This matches NONE mode's order in endFrame().
-            if (this.cloudRenderer.isAvailable()) {
-                this.profiler.begin(DhFrameProfiler.PHASE_CLOUDS);
-                this.cloudRenderer.renderIfEnabled(uniforms.partialTicks, uniforms.mcProjectionMatrix, uniforms.dhModelViewMatrix);
-                this.profiler.end(DhFrameProfiler.PHASE_CLOUDS);
-            }
 
             this.runComposite(uniforms, mcDepthR32F);
         } catch (Exception e) {

--- a/vulkan/src/main/java/com/braffolk/dhvulkan/core/VulkanRenderEngine.java
+++ b/vulkan/src/main/java/com/braffolk/dhvulkan/core/VulkanRenderEngine.java
@@ -507,14 +507,7 @@ public class VulkanRenderEngine implements VulkanBackend {
                 this.runComposite(uniforms, mcDepthForComposite);
                 this.profiler.end(DhFrameProfiler.PHASE_COMPOSITE);
             } else if (DhVulkanConfig.get().vulkanRenderMode != 6) {
-                // SINGLE/DOUBLE normal: render clouds first, then Phase 1 composite.
-                // Clouds render BEFORE composite so LODs draw on top via alpha blend,
-                // naturally occluding clouds behind tall LOD mountains.
-                if (this.cloudRenderer.isAvailable()) {
-                    this.profiler.begin(DhFrameProfiler.PHASE_CLOUDS);
-                    this.cloudRenderer.renderIfEnabled(uniforms.partialTicks, uniforms.mcProjectionMatrix, uniforms.dhModelViewMatrix);
-                    this.profiler.end(DhFrameProfiler.PHASE_CLOUDS);
-                }
+                // SINGLE/DOUBLE normal: draw LOD colors with depth=1.0 (shader handles it).
                 this.profiler.begin(DhFrameProfiler.PHASE_COMPOSITE);
                 this.runComposite(uniforms, null);
                 this.profiler.end(DhFrameProfiler.PHASE_COMPOSITE);
@@ -550,8 +543,9 @@ public class VulkanRenderEngine implements VulkanBackend {
     /**
      * Phase 2: re-composite LODs at renderLevel @RETURN (after terrain + weather).
      * Reads MC depth and re-composites LODs with per-pixel depth comparison.
-     * Open-sky LOD pixels are discarded (shader) to preserve weather.
-     * Clouds are NOT rendered here — they render in endFrame before Phase 1.
+     * Open-sky LOD pixels write their LOD depth into the MC depth buffer, but output
+     * alpha=0 so weather colors are preserved.
+     * Finally, clouds are rendered and depth-test against the fully updated MC+LOD depth buffer.
      */
     @Override
     public void lateComposite(RenderUniforms uniforms) {
@@ -575,7 +569,16 @@ public class VulkanRenderEngine implements VulkanBackend {
 
             Compat.rebindMainTarget();
 
+            // Run Phase 2 first: this writes LOD depth into the MC depth buffer for open-sky pixels
             this.runComposite(uniforms, mcDepthR32F);
+
+            // Now the depth buffer contains both MC terrain depth AND LOD depth.
+            // Clouds can accurately depth test against BOTH!
+            if (this.cloudRenderer.isAvailable()) {
+                this.profiler.begin(DhFrameProfiler.PHASE_CLOUDS);
+                this.cloudRenderer.renderIfEnabled(uniforms.partialTicks, uniforms.mcProjectionMatrix, uniforms.dhModelViewMatrix);
+                this.profiler.end(DhFrameProfiler.PHASE_CLOUDS);
+            }
         } catch (Exception e) {
             LOGGER.error("[DH-Vulkan] Phase 2 composite error", e);
             try {

--- a/vulkan/src/main/java/com/braffolk/dhvulkan/core/pipeline/DhCompositePipeline.java
+++ b/vulkan/src/main/java/com/braffolk/dhvulkan/core/pipeline/DhCompositePipeline.java
@@ -75,6 +75,7 @@ public class DhCompositePipeline {
     private MappedBuffer remapProjBuf;
     private MappedBuffer debugModeBuf;
     private MappedBuffer useMcDepthBuf;
+    private MappedBuffer isNoneModeBuf;
     private MappedBuffer startFadeDistBuf;
     private MappedBuffer endFadeDistBuf;
     private MappedBuffer startFadeDistSqBuf;
@@ -164,6 +165,10 @@ public class DhCompositePipeline {
         this.useMcDepthBuf.putInt(0, 0);
         Compat.addUniformWithBuffer(uboBuilder, "int", "uUseMcDepth", 1, () -> this.useMcDepthBuf);
 
+        this.isNoneModeBuf = new MappedBuffer(4);
+        this.isNoneModeBuf.putInt(0, 0);
+        Compat.addUniformWithBuffer(uboBuilder, "int", "uIsNoneMode", 1, () -> this.isNoneModeBuf);
+
         this.startFadeDistBuf = new MappedBuffer(4);
         this.startFadeDistBuf.putFloat(0, 0);
         Compat.addUniformWithBuffer(uboBuilder, "float", "uStartFadeBlockDist", 1, () -> this.startFadeDistBuf);
@@ -191,7 +196,8 @@ public class DhCompositePipeline {
                 java.util.Map.entry("uStartFadeBlockDist", this.startFadeDistBuf),
                 java.util.Map.entry("uEndFadeBlockDist", this.endFadeDistBuf),
                 java.util.Map.entry("uStartFadeBlockDistSq", this.startFadeDistSqBuf),
-                java.util.Map.entry("uEndFadeBlockDistSq", this.endFadeDistSqBuf)));
+                java.util.Map.entry("uEndFadeBlockDistSq", this.endFadeDistSqBuf),
+                java.util.Map.entry("uIsNoneMode", this.isNoneModeBuf)));
         ubos.add(mainUbo);
 
         // Image descriptors — DH color/depth + SSAO/fog debug + MC depth
@@ -220,7 +226,7 @@ public class DhCompositePipeline {
     public void render(VulkanImage dhColorTexture, VulkanImage dhDepthTexture,
             VulkanImage ssaoTexture, VulkanImage fogTexture,
             VulkanImage mcDepthTexture,
-            int debugMode, float[] invProjMatrix, float[] mcProjMatrix,
+            int debugMode, boolean isNoneMode, float[] invProjMatrix, float[] mcProjMatrix,
             float[] invMcMvmProjMatrix, float startFadeDist, float endFadeDist) {
         if (!this.initialized) {
             return;
@@ -229,6 +235,7 @@ public class DhCompositePipeline {
         // Update uniforms
         this.debugModeBuf.putInt(0, debugMode);
         this.useMcDepthBuf.putInt(0, mcDepthTexture != null ? 1 : 0);
+        this.isNoneModeBuf.putInt(0, isNoneMode ? 1 : 0);
         if (invProjMatrix != null && invProjMatrix.length == 16) {
             for (int i = 0; i < 16; i++) {
                 this.invProjBuf.putFloat(i * 4, invProjMatrix[i]);

--- a/vulkan/src/main/java/com/braffolk/dhvulkan/core/pipeline/DhCompositePipeline.java
+++ b/vulkan/src/main/java/com/braffolk/dhvulkan/core/pipeline/DhCompositePipeline.java
@@ -304,6 +304,7 @@ public class DhCompositePipeline {
         VRenderSystem.depthMask = true;
         // GL_ALWAYS: the shader handles depth comparison via the MC depth texture.
         // The depth test always passes, but depth WRITES still happen via gl_FragDepth.
+        // Open-sky LOD pixels are discarded in the shader to preserve weather.
         VRenderSystem.depthFun = 519; // GL_ALWAYS
         // Premultiplied alpha blending: DH's color buffer is already
         // alpha-premultiplied from DH's own transparent pass blending,

--- a/vulkan/src/main/java/com/braffolk/dhvulkan/core/pipeline/DhSsaoPipeline.java
+++ b/vulkan/src/main/java/com/braffolk/dhvulkan/core/pipeline/DhSsaoPipeline.java
@@ -314,7 +314,7 @@ public class DhSsaoPipeline {
         this.tempInvProj.invert();
         setUniformMat4(this.pass1Uniforms, "uInvProj", this.tempInvProj);
         setUniformMat4(this.pass1Uniforms, "uProj", projectionMatrix);
-        setUniformInt(this.pass1Uniforms, "uSampleCount", 4); // reduced from 6 for perf
+        setUniformInt(this.pass1Uniforms, "uSampleCount", 4);
         setUniformFloat(this.pass1Uniforms, "uRadius", 4.0f);
         // Tuned down vs GL path — MC projection gives sharper depth gradients
         // than DH projection, producing stronger occlusion from correct normals.
@@ -354,9 +354,9 @@ public class DhSsaoPipeline {
         // Pass 2: Blur + Apply //
         // ====================== //
 
-        // Fill pass 2 uniforms (use full resolution for blur sampling)
+        // Fill pass 2 uniforms
         setUniformVec2(this.pass2Uniforms, "gViewSize", this.width, this.height);
-        setUniformInt(this.pass2Uniforms, "gBlurRadius", 0); // skip blur — bilinear filtering suffices
+        setUniformInt(this.pass2Uniforms, "gBlurRadius", 2); // 5×5 depth-aware bilateral blur
         setUniformFloat(this.pass2Uniforms, "gNear", 0.05f); // MC default near clip
         setUniformFloat(this.pass2Uniforms, "gFar", (float) RenderUtil.getFarClipPlaneDistanceInBlocks());
         setUniformInt(this.pass2Uniforms, "uDebugMode", 0);

--- a/vulkan/src/main/java/com/braffolk/dhvulkan/core/pipeline/DhSsaoPipeline.java
+++ b/vulkan/src/main/java/com/braffolk/dhvulkan/core/pipeline/DhSsaoPipeline.java
@@ -110,6 +110,33 @@ public class DhSsaoPipeline {
     // Pre-allocated temp matrix to avoid per-frame heap allocation
     private final Mat4f tempInvProj = new Mat4f();
 
+    // Cached method handle for RenderUtil.getFarClipPlaneDistanceInBlocks()
+    // DH 2.4 returns int, DH 3.0 returns float — JVM treats return type as part
+    // of the method signature, so we must resolve at runtime via reflection.
+    private static java.lang.reflect.Method farClipMethod;
+    private static boolean farClipMethodResolved = false;
+
+    private static float getFarClipSafe() {
+        if (!farClipMethodResolved) {
+            farClipMethodResolved = true;
+            try {
+                // Try float first (DH 3.0)
+                farClipMethod = RenderUtil.class.getMethod("getFarClipPlaneDistanceInBlocks");
+            } catch (NoSuchMethodException e) {
+                farClipMethod = null;
+            }
+        }
+        if (farClipMethod != null) {
+            try {
+                Object result = farClipMethod.invoke(null);
+                return ((Number) result).floatValue();
+            } catch (Exception e) {
+                // fall through
+            }
+        }
+        return 2400.0f; // safe default
+    }
+
     // SSAO sample count and pre-computed offsets
     private static final int SSAO_SAMPLE_COUNT = 4;
     private static final float GOLDEN_ANGLE = 2.39996323f;
@@ -358,7 +385,7 @@ public class DhSsaoPipeline {
         setUniformVec2(this.pass2Uniforms, "gViewSize", this.width, this.height);
         setUniformInt(this.pass2Uniforms, "gBlurRadius", 2); // 5×5 depth-aware bilateral blur
         setUniformFloat(this.pass2Uniforms, "gNear", 0.05f); // MC default near clip
-        setUniformFloat(this.pass2Uniforms, "gFar", (float) RenderUtil.getFarClipPlaneDistanceInBlocks());
+        setUniformFloat(this.pass2Uniforms, "gFar", getFarClipSafe());
         setUniformInt(this.pass2Uniforms, "uDebugMode", 0);
 
         // Bind raw SSAO texture + DH depth for the apply pass

--- a/vulkan/src/main/java/com/braffolk/dhvulkan/core/pipeline/DhSsaoPipeline.java
+++ b/vulkan/src/main/java/com/braffolk/dhvulkan/core/pipeline/DhSsaoPipeline.java
@@ -110,9 +110,10 @@ public class DhSsaoPipeline {
     // Pre-allocated temp matrix to avoid per-frame heap allocation
     private final Mat4f tempInvProj = new Mat4f();
 
-    // Cached method handle for RenderUtil.getFarClipPlaneDistanceInBlocks()
-    // DH 2.4 returns int, DH 3.0 returns float — JVM treats return type as part
-    // of the method signature, so we must resolve at runtime via reflection.
+    // [DH 2.4 COMPAT] RenderUtil.getFarClipPlaneDistanceInBlocks() returns int in
+    // DH 2.4 but float in DH 3.0. JVM treats return type as part of the method
+    // signature, so we resolve via reflection to support both.
+    // When dropping DH 2.4: replace with direct call to RenderUtil.getFarClipPlaneDistanceInBlocks().
     private static java.lang.reflect.Method farClipMethod;
     private static boolean farClipMethodResolved = false;
 
@@ -120,7 +121,6 @@ public class DhSsaoPipeline {
         if (!farClipMethodResolved) {
             farClipMethodResolved = true;
             try {
-                // Try float first (DH 3.0)
                 farClipMethod = RenderUtil.class.getMethod("getFarClipPlaneDistanceInBlocks");
             } catch (NoSuchMethodException e) {
                 farClipMethod = null;

--- a/vulkan/src/main/java/com/braffolk/dhvulkan/mixin/shared/MixinLevelRenderer.java
+++ b/vulkan/src/main/java/com/braffolk/dhvulkan/mixin/shared/MixinLevelRenderer.java
@@ -11,46 +11,53 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 /**
  * Mixin into Minecraft's {@link LevelRenderer}.
  *
- * At {@code addCloudsPass @HEAD}:
- * 1. Triggers Phase 2 deferred composite via Compat hook — reads MC depth
- *    (terrain has rendered by now) and re-composites DH LODs with per-pixel
- *    depth comparison. Also renders DH clouds after composite.
- * 2. Optionally cancels vanilla cloud rendering when DH overrides it.
+ * Phase 2 deferred composite runs at renderLevel @RETURN (after weather).
+ * The composite uses GL_LEQUAL depth test so it won't overwrite weather pixels
+ * (weather writes depth < 1.0, Phase 2 writes gl_FragDepth = 1.0 at open-sky
+ * LODs, so LEQUAL fails and weather is preserved).
  *
- * This hook fires AFTER terrain but BEFORE weather, so the weather fix
- * (from d46c003) is preserved.
+ * Cloud cancellation hooks at addCloudsPass/renderClouds (require=0).
  */
 @Mixin(LevelRenderer.class)
 public class MixinLevelRenderer {
 
+    /**
+     * Cancel vanilla clouds when DH overrides them (1.20.6 hook).
+     */
     @Inject(method = "addCloudsPass", at = @At("HEAD"), cancellable = true, require = 0)
-    private void dhvulkan$deferredCompositeAndClouds(CallbackInfo ci) {
+    private void dhvulkan$cancelVanillaClouds120(CallbackInfo ci) {
         if (!Compat.isVulkanModActive()) return;
-
-        // Phase 2a: read MC depth + render clouds
-        Compat.runDeferredCompositeHook();
-
-        // Cancel vanilla clouds when DH overrides them
         try {
             if (Config.Client.Advanced.Graphics.overrideVanillaGraphicsSettings.get()) {
                 ci.cancel();
             }
-        } catch (Exception e) {
-            // Config not yet available — let vanilla clouds render
-        }
+        } catch (Exception e) {}
     }
 
     /**
-     * Phase 2b: late re-composite at renderLevel @RETURN.
-     * This fires AFTER terrain + weather + everything else in renderLevel.
-     * Re-composites DH LODs with real MC depth for SINGLE/DOUBLE fade modes.
-     * Same hook point as vm.5's deferredComposite.
+     * Cancel vanilla clouds when DH overrides them (1.21.11 hook).
+     */
+    @Inject(method = "renderClouds", at = @At("HEAD"), cancellable = true, require = 0)
+    private void dhvulkan$cancelVanillaClouds121(CallbackInfo ci) {
+        if (!Compat.isVulkanModActive()) return;
+        try {
+            if (Config.Client.Advanced.Graphics.overrideVanillaGraphicsSettings.get()) {
+                ci.cancel();
+            }
+        } catch (Exception e) {}
+    }
+
+    /**
+     * Phase 2: deferred composite at renderLevel @RETURN.
+     * Fires AFTER terrain + weather + everything.
+     * Uses GL_LEQUAL depth test so weather pixels (depth < 1.0) are preserved —
+     * the composite writes gl_FragDepth = 1.0 at open-sky LODs, which fails
+     * LEQUAL against weather's depth.
      */
     @Inject(method = "renderLevel", at = @At("RETURN"))
     private void dhvulkan$lateComposite(CallbackInfo ci) {
         if (!Compat.isVulkanModActive()) return;
-
-        // Phase 2b: re-composite with real MC depth
         Compat.runLateCompositeHook();
     }
+
 }

--- a/vulkan/src/main/resources/shaders/vulkan/dh_apply.frag
+++ b/vulkan/src/main/resources/shaders/vulkan/dh_apply.frag
@@ -154,8 +154,10 @@ void main() {
         if (uIsNoneMode != 0) {
             // In NONE mode, MC terrain doesn't overlap LODs. 
             // Write the true LOD depth so Phase 1 accurately occludes clouds!
+            // Small bias pushes LODs slightly behind MC terrain to prevent z-fighting
+            // at the overlap boundary (MC terrain wins at equal depth).
             float mcCompatibleDepth = remapDepthDhToMc(TexCoord, dhDepth);
-            gl_FragDepth = clamp(mcCompatibleDepth, 0.0, 1.0);
+            gl_FragDepth = clamp(mcCompatibleDepth + 0.0001, 0.0, 1.0);
         } else {
             // For SINGLE/DOUBLE, we must write far-plane depth so MC terrain AND
             // weather both render freely on top via LEQUAL (prevents intense Z-fighting 

--- a/vulkan/src/main/resources/shaders/vulkan/dh_apply.frag
+++ b/vulkan/src/main/resources/shaders/vulkan/dh_apply.frag
@@ -27,7 +27,8 @@ layout(set = 0, binding = 5) uniform sampler2D gMcDepthTexture;
  * Reconstruct view-space position from DH depth using DH's inverse projection.
  */
 vec3 reconstructViewPos(vec2 uv, float depth) {
-    vec3 clipPos = vec3(uv, depth) * 2.0 - 1.0;
+    // Vulkan NDC: X,Y in [-1, 1], Z in [0, 1]
+    vec3 clipPos = vec3(uv * 2.0 - 1.0, depth);
     vec4 viewPos = uInvProj * vec4(clipPos, 1.0);
     return viewPos.xyz / viewPos.w;
 }
@@ -40,9 +41,11 @@ vec3 reconstructViewPos(vec2 uv, float depth) {
  * with MC's projection.
  */
 float remapDepthDhToMc(vec2 uv, float dhDepth) {
+    // Vulkan NDC: X,Y in [-1, 1], Z in [0, 1]
     // Single mat4 multiply: uRemapProj = uMcProj * uInvProj (pre-multiplied on CPU)
-    vec4 mcClip = uRemapProj * vec4(vec3(uv, dhDepth) * 2.0 - 1.0, 1.0);
-    return (mcClip.z / mcClip.w) * 0.5 + 0.5;
+    vec4 mcClip = uRemapProj * vec4(uv * 2.0 - 1.0, dhDepth, 1.0);
+    // Vulkan clip space Z/W is already in [0, 1], so we return it directly
+    return mcClip.z / mcClip.w;
 }
 
 /**
@@ -93,11 +96,12 @@ void main() {
             }
         } else {
             // No MC terrain at this pixel (open sky behind LODs).
-            // Phase 1 already composited LODs here with depth 1.0.
-            // Weather/particles may have rendered on top since Phase 1.
-            // Do NOT redraw — discard to preserve whatever is currently on screen.
-            // This fixed rain and snow rendering on NVIDIA.
-            discard;
+            // We want to write LOD depth so clouds can accurately depth-test
+            // against LOD mountains! 
+            // BUT we must NOT overwrite weather/particles that are already on screen.
+            // By emitting alpha=0, Phase 2's blending leaves the color buffer completely 
+            // unchanged (weather is preserved), but it still writes gl_FragDepth!
+            fadeMultiplier = 0.0;
         }
     }
 
@@ -138,15 +142,12 @@ void main() {
 
     if (uUseMcDepth != 0) {
         float mcDepth = texture(gMcDepthTexture, TexCoord).r;
-        if (mcDepth < 1.0) {
-            // MC terrain exists — write remapped depth for fade transition.
-            float mcCompatibleDepth = remapDepthDhToMc(TexCoord, dhDepth);
-            gl_FragDepth = clamp(mcCompatibleDepth, 0.0, 0.999);
-        } else {
-            // Open sky — but we already discarded above, so this is unreachable
-            // when uUseMcDepth is set. Safety fallback.
-            gl_FragDepth = 1.0;
-        }
+        
+        // Write MC-compatible LOD depth for ALL DH pixels in Phase 2.
+        // If mcDepth < 1.0, this handles the fade transition.
+        // If mcDepth >= 1.0, this updates the MC depth buffer so clouds can depth-test!
+        float mcCompatibleDepth = remapDepthDhToMc(TexCoord, dhDepth);
+        gl_FragDepth = clamp(mcCompatibleDepth, 0.0, 1.0);
     } else {
         // Phase 1 (without MC depth): write far-plane depth so MC terrain AND
         // weather both render freely on top via LEQUAL. LOD colors are still

--- a/vulkan/src/main/resources/shaders/vulkan/dh_apply.frag
+++ b/vulkan/src/main/resources/shaders/vulkan/dh_apply.frag
@@ -139,19 +139,18 @@ void main() {
     if (uUseMcDepth != 0) {
         float mcDepth = texture(gMcDepthTexture, TexCoord).r;
         if (mcDepth < 1.0) {
-            // MC terrain exists at this pixel — write remapped depth for fade transition.
+            // MC terrain exists — write remapped depth for fade transition.
             float mcCompatibleDepth = remapDepthDhToMc(TexCoord, dhDepth);
             gl_FragDepth = clamp(mcCompatibleDepth, 0.0, 0.999);
         } else {
-            // No MC terrain (open sky) — write 1.0 so weather, particles, and
-            // other effects rendered after this composite pass freely via LEQUAL.
+            // Open sky — but we already discarded above, so this is unreachable
+            // when uUseMcDepth is set. Safety fallback.
             gl_FragDepth = 1.0;
         }
     } else {
         // Phase 1 (without MC depth): write far-plane depth so MC terrain AND
         // weather both render freely on top via LEQUAL. LOD colors are still
         // blended onto the swapchain — only the depth is transparent.
-        // Phase 2b re-composites with proper depth after weather renders.
         gl_FragDepth = 1.0;
     }
 }

--- a/vulkan/src/main/resources/shaders/vulkan/dh_apply.frag
+++ b/vulkan/src/main/resources/shaders/vulkan/dh_apply.frag
@@ -11,6 +11,7 @@ layout(std140, binding = 0) uniform CompositeUBO {
     mat4 uRemapProj;        // = uMcProj * uInvProj — fused unproject+reproject (1× mat4 instead of 2×)
     int uDebugMode;         // 0=off, 1=depth, 2=ssao, 3=fog_alpha, 4=fog_color, 5=normals, 6=mc_depth
     int uUseMcDepth;        // 0=no MC depth comparison, 1=use MC depth for fade
+    int uIsNoneMode;        // 1=NONE mode (no overlap), 0=SINGLE/DOUBLE phase 1
     float uStartFadeBlockDist;  // distance where DH fade begins (blocks)
     float uEndFadeBlockDist;    // distance where DH fade ends (blocks)
     float uStartFadeBlockDistSq; // squared, for dot() instead of length()
@@ -149,9 +150,17 @@ void main() {
         float mcCompatibleDepth = remapDepthDhToMc(TexCoord, dhDepth);
         gl_FragDepth = clamp(mcCompatibleDepth, 0.0, 1.0);
     } else {
-        // Phase 1 (without MC depth): write far-plane depth so MC terrain AND
-        // weather both render freely on top via LEQUAL. LOD colors are still
-        // blended onto the swapchain — only the depth is transparent.
-        gl_FragDepth = 1.0;
+        // Phase 1 (without MC depth):
+        if (uIsNoneMode != 0) {
+            // In NONE mode, MC terrain doesn't overlap LODs. 
+            // Write the true LOD depth so Phase 1 accurately occludes clouds!
+            float mcCompatibleDepth = remapDepthDhToMc(TexCoord, dhDepth);
+            gl_FragDepth = clamp(mcCompatibleDepth, 0.0, 1.0);
+        } else {
+            // For SINGLE/DOUBLE, we must write far-plane depth so MC terrain AND
+            // weather both render freely on top via LEQUAL (prevents intense Z-fighting 
+            // during MC solid/translucent passes). LOD colors are strictly blended.
+            gl_FragDepth = 1.0;
+        }
     }
 }

--- a/vulkan/src/main/resources/shaders/vulkan/dh_terrain.vert
+++ b/vulkan/src/main/resources/shaders/vulkan/dh_terrain.vert
@@ -95,5 +95,5 @@ void main()
 
     gl_Position = uCombinedMatrix * vec4(vertexWorldPos, 1.0);
 
-    gl_ClipDistance[0] = length(vertexWorldPos.xz) - uClipDistance;
+    gl_ClipDistance[0] = length(vertexWorldPos) - uClipDistance;
 }


### PR DESCRIPTION
## v2.4.0-3.0.0+vm.2 - NVIDIA weather effects, SSAO smoothing, and rendering fixes

**Hotfix** — weather effects (rain, snow, particles) now render correctly in front of LODs on all GPUs. Fast clouds no longer render on top of LODs. Previously, the Phase 2 composite was overwriting weather pixels with LOD colors on NVIDIA and potentially other non-MoltenVK drivers.

- **SSAO smoothing** — enabled the bilateral Gaussian blur on SSAO output. Previously the blur was disabled (radius 0), causing visibly grainy/noisy ambient occlusion.
- **Z-fighting fix (NONE mode)** — added small depth bias to LOD depth output in NONE fade mode, preventing z-fighting at the MC/LOD overlap boundary.
- **High-altitude LOD gap fix** — LOD clip distance now uses 3D distance instead of XZ-only. Previously, flying high and looking down created a visible gap between MC terrain and LODs because the cylindrical XZ clip didn't match MC's spherical render distance.