### PR TITLE
Port to MC 1.21.1 (DH 3.2.0-b, VulkanMod 0.6.7)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -52,7 +52,7 @@ versionStr=
 
 # This defines what MC version Intellij will use for the preprocessor
 # and what version is used automatically by build and run commands
-mcVer=1.21.11
+mcVer=1.21.1
 
 # Defines the maximum amount of memory Minecraft is allowed when run in a development environment
 #minecraftMemoryJavaArg="-Xmx4G"

--- a/vulkan/build.gradle
+++ b/vulkan/build.gradle
@@ -39,6 +39,18 @@ def vmJar = fileTree("${rootDir}/jars").matching { include "VulkanMod_${mcVer}-*
 if (dhJar.isEmpty()) throw new GradleException("No DH jar found for MC ${mcVer} in jars/")
 if (vmJar.isEmpty()) throw new GradleException("No VulkanMod jar found for MC ${mcVer} in jars/")
 
+// The legacy DH 2.4 ("dh24") integration only compiles against a DH 2.x jar
+// (uses GLProxy / GLVertexBuffer / LodBufferContainer.vbos, etc.). When no DH 2.x
+// jar is present in jars/, exclude that module and build the DH 3.x path only.
+def dh24Jar = fileTree("${rootDir}/jars").matching { include "DistantHorizons-2.*-${mcVer}-*.jar" }.files
+if (dh24Jar.isEmpty()) {
+    sourceSets.main.java {
+        exclude "com/braffolk/dhvulkan/dh24/**"
+        exclude "com/braffolk/dhvulkan/mixin/dh24/**"
+    }
+    logger.lifecycle("[DH-VulkanMod] No DH 2.x jar for MC ${mcVer} — excluding legacy dh24 module (DH 3.x-only build).")
+}
+
 dependencies {
     minecraft "com.mojang:minecraft:${mcVer}"
     mappings loom.layered() {

--- a/vulkan/src/main/java/com/braffolk/dhvulkan/DhVulkanModEntrypoint.java
+++ b/vulkan/src/main/java/com/braffolk/dhvulkan/DhVulkanModEntrypoint.java
@@ -5,7 +5,6 @@ import com.braffolk.dhvulkan.bridge.DhVersionDetector;
 import com.braffolk.dhvulkan.config.DhVulkanConfig;
 import com.braffolk.dhvulkan.core.VulkanBackend;
 import com.braffolk.dhvulkan.core.VulkanRenderEngine;
-import com.braffolk.dhvulkan.dh24.Dh24Integration;
 import com.braffolk.dhvulkan.compat.Compat;
 import com.mojang.brigadier.arguments.IntegerArgumentType;
 import net.fabricmc.api.ClientModInitializer;
@@ -81,9 +80,11 @@ public class DhVulkanModEntrypoint implements ClientModInitializer {
                 break;
             case DH_2_4:
             default:
-                activeIntegration = new Dh24Integration();
-                activeIntegration.initialize(backend);
-                break;
+                // This build ships only the DH 3.x (API) integration path.
+                // The legacy DH 2.4 (dh24) module is not compiled in.
+                LOGGER.warn("[DH-VulkanMod] Detected DH {} but this build only supports DH 3.x. "
+                        + "Extension will be inactive.", dhVersion);
+                return;
         }
 
         LOGGER.info("[DH-VulkanMod] Using integration: {}", activeIntegration.getName());
@@ -94,8 +95,8 @@ public class DhVulkanModEntrypoint implements ClientModInitializer {
      * delegate. Only applies to DH 2.4 path.
      */
     public static void wireIfNeeded() {
-        if (activeIntegration instanceof Dh24Integration) {
-            ((Dh24Integration) activeIntegration).wireIfNeeded();
+        if (activeIntegration != null) {
+            activeIntegration.wireIfNeeded();
         }
     }
 

--- a/vulkan/src/main/java/com/braffolk/dhvulkan/api/VkLodContainerUniformWrapper.java
+++ b/vulkan/src/main/java/com/braffolk/dhvulkan/api/VkLodContainerUniformWrapper.java
@@ -8,22 +8,14 @@ import com.seibel.distanthorizons.core.wrapperInterfaces.render.objects.ILodCont
  * In the OpenGL path this manages per-section UBO data. In Vulkan,
  * our engine handles uniform uploads internally via push constants
  * and the fillUniforms() / setModelOffset() pipeline, so this is a no-op.
+ *
+ * DH 3.2.0-b interface: {@code tryUpload(LodBufferContainer)} + {@code close()}.
  */
 public class VkLodContainerUniformWrapper implements ILodContainerUniformBufferWrapper {
 
     @Override
-    public void createUniformData(LodBufferContainer bufferContainer) {
+    public void tryUpload(LodBufferContainer bufferContainer) {
         // No-op: Vulkan engine manages uniforms internally
-    }
-
-    @Override
-    public void tryUpload() {
-        // No-op
-    }
-
-    @Override
-    public void upload() {
-        // No-op
     }
 
     @Override

--- a/vulkan/src/main/java/com/braffolk/dhvulkan/api/VkRenderApiDefinition.java
+++ b/vulkan/src/main/java/com/braffolk/dhvulkan/api/VkRenderApiDefinition.java
@@ -7,7 +7,7 @@ import com.seibel.distanthorizons.api.interfaces.render.IDhApiRenderableBoxGroup
 import com.seibel.distanthorizons.core.dataObjects.render.bufferBuilding.LodBufferContainer;
 import com.seibel.distanthorizons.core.render.RenderParams;
 import com.seibel.distanthorizons.core.render.renderer.AbstractDebugWireframeRenderer;
-import com.seibel.distanthorizons.core.util.math.Vec3f;
+import com.seibel.distanthorizons.core.util.math.DhVec3f;
 import com.seibel.distanthorizons.core.wrapperInterfaces.minecraft.IProfilerWrapper;
 import com.seibel.distanthorizons.core.util.objects.SortedArraySet;
 import com.seibel.distanthorizons.core.wrapperInterfaces.render.AbstractDhRenderApiDefinition;
@@ -51,7 +51,16 @@ public class VkRenderApiDefinition extends AbstractDhRenderApiDefinition {
         // Init is deferred to the first runRenderPassSetup() call.
     }
 
-    @Override public String getApiName() { return "VulkanMod"; }
+    @Override public String getEngineName() { return "VulkanMod"; }
+
+    // DH 3.2.0-b render-definition metadata
+    @Override public boolean isNativeRenderer() { return true; }
+    @Override public com.seibel.distanthorizons.api.enums.config.EDhApiRenderingApi getRenderApi() {
+        return com.seibel.distanthorizons.api.enums.config.EDhApiRenderingApi.VULKAN;
+    }
+    @Override public com.seibel.distanthorizons.core.render.EDhRenderDepth getRenderDepth() {
+        return com.seibel.distanthorizons.core.render.EDhRenderDepth.FORWARD_Z;
+    }
 
     // Singletons
     @Override public IDhMetaRenderer getMetaRenderer() { return metaRenderer; }
@@ -76,9 +85,8 @@ public class VkRenderApiDefinition extends AbstractDhRenderApiDefinition {
     // =========================================== //
 
     static RenderUniforms toUniforms(RenderParams params, RenderUniforms target) {
-        target.set((com.seibel.distanthorizons.core.util.math.Mat4f) (Object) params.dhProjectionMatrix,
-              (com.seibel.distanthorizons.core.util.math.Mat4f) (Object) params.dhModelViewMatrix,
-              (com.seibel.distanthorizons.core.util.math.Mat4f) (Object) params.mcProjectionMatrix);
+        // DH 3.2.0-b exposes matrices as DhApiMat4f; RenderUniforms.set() copies them.
+        target.set(params.dhProjectionMatrix, params.dhModelViewMatrix, params.mcProjectionMatrix);
         target.worldYOffset = params.worldYOffset;
         target.partialTicks = params.partialTicks;
         return target;
@@ -159,7 +167,7 @@ public class VkRenderApiDefinition extends AbstractDhRenderApiDefinition {
         private final VulkanBackend backend;
 
         // Cached to avoid per-container allocation in the render loop
-        private final Vec3f reusableModelPos = new Vec3f(0, 0, 0);
+        private final DhVec3f reusableModelPos = new DhVec3f(0, 0, 0);
 
         // Cached reflection fields for VBO arrays in LodBufferContainer.
         // DH 3.0: vboOpaqueWrappers / vboTransparentWrappers
@@ -216,7 +224,7 @@ public class VkRenderApiDefinition extends AbstractDhRenderApiDefinition {
                 LodBufferContainer container = bufferContainers.get(lodIndex);
 
                 // Compute model offset relative to camera (matches GL reference)
-                com.seibel.distanthorizons.core.util.math.Vec3d camPos = renderEventParam.exactCameraPosition;
+                com.seibel.distanthorizons.core.util.math.DhVec3d camPos = renderEventParam.exactCameraPosition;
                 if (camPos != null) {
                     this.reusableModelPos.set(
                         (float) (container.minCornerBlockPos.getX() - camPos.x),
@@ -255,7 +263,11 @@ public class VkRenderApiDefinition extends AbstractDhRenderApiDefinition {
     }
 
     static class VkFogRenderer implements IDhFogRenderer {
-        @Override public void render(RenderParams renderParams) { /* handled internally by VulkanBackend */ }
+        // DH 3.2.0-b added the DhApiFogRenderParam argument
+        @Override public void render(RenderParams renderParams,
+                com.seibel.distanthorizons.api.methods.events.sharedParameterObjects.DhApiFogRenderParam fogParam) {
+            /* handled internally by VulkanBackend */
+        }
     }
 
     static class VkFarFadeRenderer implements IDhFarFadeRenderer {
@@ -296,6 +308,11 @@ public class VkRenderApiDefinition extends AbstractDhRenderApiDefinition {
         @Override
         public IDhApiRenderableBoxGroup remove(long id) {
             return null; // Not yet implemented
+        }
+
+        @Override
+        public void close() {
+            // Nothing to release — generic object rendering is not implemented
         }
     }
 }

--- a/vulkan/src/main/java/com/braffolk/dhvulkan/api/VkVertexBufferWrapper.java
+++ b/vulkan/src/main/java/com/braffolk/dhvulkan/api/VkVertexBufferWrapper.java
@@ -33,18 +33,13 @@ public class VkVertexBufferWrapper implements IVertexBufferWrapper {
         this.id = nextId++;
     }
 
-    // [DH 2.4 COMPAT] DH 2.4 calls upload(); DH 3.0 calls uploadVertexBuffer().
-    // Remove this method when dropping DH 2.4 support.
+    // DH 3.x interface methods
     @Override
-    public void upload(ByteBuffer buffer, int vertexCount) {
-        uploadVertexBufferImpl(buffer, vertexCount);
-    }
-
-    // DH 3.0 interface methods
     public void uploadVertexBuffer(ByteBuffer buffer, int vertexCount) {
         uploadVertexBufferImpl(buffer, vertexCount);
     }
 
+    @Override
     public void uploadIndexBuffer(ByteBuffer buffer, int vertexCount) {
         // No-op — we use a shared IBO (useSingleIbo() returns true)
     }

--- a/vulkan/src/main/java/com/braffolk/dhvulkan/bridge/DhIntegration.java
+++ b/vulkan/src/main/java/com/braffolk/dhvulkan/bridge/DhIntegration.java
@@ -17,4 +17,12 @@ public interface DhIntegration {
 
     /** Human-readable name for logging */
     String getName();
+
+    /**
+     * Late wiring hook. Only the DH 2.4 path needs this (it wires its render
+     * delegate from a mixin before the first render pass); DH 3.x wires via the
+     * API at init, so the default is a no-op. Keeping it on the interface lets the
+     * entrypoint stay decoupled from the (optional) dh24 module.
+     */
+    default void wireIfNeeded() {}
 }

--- a/vulkan/src/main/java/com/braffolk/dhvulkan/compat/Compat.java
+++ b/vulkan/src/main/java/com/braffolk/dhvulkan/compat/Compat.java
@@ -356,7 +356,8 @@ public final class Compat {
         net.vulkanmod.vulkan.shader.layout.Uniform.Info info =
                 net.vulkanmod.vulkan.shader.layout.Uniform.createUniformInfo(type, name, count);
         info.setBufferSupplier(bufferSupplier);
-        builder.addUniformInfo(info);
+        // VM 0.6.7: AlignedStruct.Builder.addUniform(Uniform.Info) (was addUniformInfo on 0.6.1)
+        builder.addUniform(info);
         #else
         builder.addUniformInfo(type, name, count);
         #endif
@@ -398,12 +399,16 @@ public final class Compat {
         net.vulkanmod.vulkan.shader.layout.Uniform.Info info =
                 net.vulkanmod.vulkan.shader.layout.Uniform.createUniformInfo(type, name, count);
         info.setBufferSupplier(bufferSupplier);
-        pcBuilder.addUniformInfo(info);
+        // VM 0.6.7: addUniform(Info) (was addUniformInfo); buildPushConstant now
+        // takes the VkShaderStageFlags the push constant is visible to. The DH
+        // terrain push_constant block (uModelOffset) lives only in the vertex shader.
+        pcBuilder.addUniform(info);
         try {
             java.lang.reflect.Field pcField =
                     net.vulkanmod.vulkan.shader.Pipeline.Builder.class.getDeclaredField("pushConstants");
             pcField.setAccessible(true);
-            pcField.set(pipelineBuilder, pcBuilder.buildPushConstant());
+            pcField.set(pipelineBuilder,
+                    pcBuilder.buildPushConstant(org.lwjgl.vulkan.VK10.VK_SHADER_STAGE_VERTEX_BIT));
         } catch (Exception e) {
             throw new RuntimeException("[DH-Vulkan] Failed to set push constants on pipeline builder", e);
         }
@@ -443,12 +448,57 @@ public final class Compat {
     }
 
     // ========================= //
+    // Pipeline shader source    //
+    // ========================= //
+
+    /**
+     * Attach vertex + fragment GLSL sources to a pipeline builder.
+     * VM 0.6.7 replaced {@code Pipeline.Builder.compileShaders(name, vert, frag)}
+     * with per-stage {@code setShaderSrc(ShaderKind, src)} (compilation is deferred
+     * to createGraphicsPipeline()).
+     */
+    public static void compilePipelineShaders(
+            net.vulkanmod.vulkan.shader.Pipeline.Builder builder,
+            String name, String vertSource, String fragSource) {
+        #if MC_VER >= MC_1_21_1
+        builder.setShaderSrc(net.vulkanmod.vulkan.shader.SPIRVUtils.ShaderKind.VERTEX_SHADER, vertSource);
+        builder.setShaderSrc(net.vulkanmod.vulkan.shader.SPIRVUtils.ShaderKind.FRAGMENT_SHADER, fragSource);
+        #else
+        builder.compileShaders(name, vertSource, fragSource);
+        #endif
+    }
+
+    // ========================= //
+    // Image descriptors         //
+    // ========================= //
+
+    /**
+     * Build a combined-image-sampler descriptor.
+     * VM 0.6.7's {@code ImageDescriptor} constructor added a trailing
+     * {@code descriptorType} arg; {@code sampler2D} maps to
+     * VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER.
+     */
+    public static net.vulkanmod.vulkan.shader.descriptor.ImageDescriptor createImageDescriptor(
+            int binding, String qualifier, String name, int imageIdx) {
+        #if MC_VER >= MC_1_21_1
+        return new net.vulkanmod.vulkan.shader.descriptor.ImageDescriptor(
+                binding, qualifier, name, imageIdx,
+                org.lwjgl.vulkan.VK10.VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER);
+        #else
+        return new net.vulkanmod.vulkan.shader.descriptor.ImageDescriptor(
+                binding, qualifier, name, imageIdx);
+        #endif
+    }
+
+    // ========================= //
     // GlTexture / Lightmap //
     // ========================= //
 
     public static VulkanImage getLightmapVulkanImage() {
         try {
-            #if MC_VER >= MC_1_21_1
+            #if MC_VER >= MC_1_21_5
+            // MC 1.21.5+ (Blaze3D GPU rewrite): the lightmap exposes a GpuTextureView
+            // backed by a GlTexture under VulkanMod's GL emulation.
             var lightmapView = net.minecraft.client.Minecraft.getInstance()
                     .gameRenderer.lightTexture().getTextureView();
             if (lightmapView == null) return null;
@@ -456,6 +506,14 @@ public final class Compat {
                     (com.mojang.blaze3d.opengl.GlTexture) lightmapView.texture();
             net.vulkanmod.gl.VkGlTexture vkGlTex =
                     net.vulkanmod.gl.VkGlTexture.getTexture(glTex.glId());
+            return vkGlTex != null ? vkGlTex.getVulkanImage() : null;
+            #elif MC_VER >= MC_1_21_1
+            // MC 1.21.1-1.21.4 (pre-GPU-rewrite): the lightmap is a DynamicTexture
+            // whose GL texture id VulkanMod maps to a VkGlTexture. VM 0.6.x keeps
+            // the emulated GL texture map, so look the id up there directly.
+            int glId = getLightmapGlId();
+            if (glId <= 0) return null;
+            net.vulkanmod.gl.VkGlTexture vkGlTex = net.vulkanmod.gl.VkGlTexture.getTexture(glId);
             return vkGlTex != null ? vkGlTex.getVulkanImage() : null;
             #else
             // VM 0.4.2: MC already binds lightmap to slot 2 before our hook fires.
@@ -466,6 +524,38 @@ public final class Compat {
             return null;
         }
     }
+
+    #if MC_VER < MC_1_21_5
+    /** Cached LightTexture->DynamicTexture field (resolved by TYPE so it survives
+     *  intermediary remapping at runtime; string field names would not). */
+    private static java.lang.reflect.Field lightmapDynTexField;
+    private static boolean lightmapDynTexResolved = false;
+
+    /**
+     * Get the GL texture id of MC's lightmap the pre-GPU-rewrite way
+     * (LightTexture wraps a DynamicTexture / AbstractTexture with a GL id).
+     * @return the GL id, or -1 if unavailable.
+     */
+    private static int getLightmapGlId() throws Exception {
+        net.minecraft.client.renderer.LightTexture lt =
+                net.minecraft.client.Minecraft.getInstance().gameRenderer.lightTexture();
+        if (lt == null) return -1;
+        if (!lightmapDynTexResolved) {
+            lightmapDynTexResolved = true;
+            for (java.lang.reflect.Field f : net.minecraft.client.renderer.LightTexture.class.getDeclaredFields()) {
+                if (net.minecraft.client.renderer.texture.DynamicTexture.class.isAssignableFrom(f.getType())) {
+                    f.setAccessible(true);
+                    lightmapDynTexField = f;
+                    break;
+                }
+            }
+        }
+        if (lightmapDynTexField == null) return -1;
+        net.minecraft.client.renderer.texture.DynamicTexture dyn =
+                (net.minecraft.client.renderer.texture.DynamicTexture) lightmapDynTexField.get(lt);
+        return dyn != null ? dyn.getId() : -1;
+    }
+    #endif
 
     // ========================= //
     // Config value scaling //
@@ -817,7 +907,8 @@ public final class Compat {
      * MC 1.21.x has options.cloudRange(), MC 1.20.x uses renderDistance.
      */
     public static int getCloudRenderRange() {
-        #if MC_VER <= MC_1_20_6
+        #if MC_VER <= MC_1_21_4
+        // MC <= 1.21.4: no Options.cloudRange(); fall back to render distance.
         return net.minecraft.client.Minecraft.getInstance().options.renderDistance().get() * 16;
         #else
         return Math.min(net.minecraft.client.Minecraft.getInstance().options.cloudRange().get(), 128) * 16;
@@ -829,7 +920,9 @@ public final class Compat {
      * MC 1.21.x has getPixelsABGR(), MC 1.20.x has getPixelRGBA per-pixel.
      */
     public static int[] getCloudPixels(com.mojang.blaze3d.platform.NativeImage image) {
-        #if MC_VER <= MC_1_20_6
+        #if MC_VER <= MC_1_21_4
+        // MC <= 1.21.4: no NativeImage.getPixelsABGR(); read per-pixel.
+        // getPixelRGBA returns the raw ABGR-packed int (same layout as getPixelsABGR).
         int width = image.getWidth();
         int height = image.getHeight();
         int[] pixels = new int[width * height];
@@ -861,6 +954,9 @@ public final class Compat {
                 return opt.orElse(-1);
             }
             return 192; // fallback overworld
+            #elif MC_VER <= MC_1_21_4
+            // MC 1.21.1-1.21.4: no DimensionType.cloudHeight(); overworld clouds at y=192
+            return level.dimensionType().hasSkyLight() ? 192 : -1;
             #elif MC_VER <= MC_1_21_10
             java.util.Optional<Integer> opt = level.dimensionType().cloudHeight();
             return opt.orElse(-1);

--- a/vulkan/src/main/java/com/braffolk/dhvulkan/compat/Compat.java
+++ b/vulkan/src/main/java/com/braffolk/dhvulkan/compat/Compat.java
@@ -326,8 +326,13 @@ public final class Compat {
      * Renderer state — we must fix up boundFramebuffer/boundRenderPass afterward.
      */
     public static void rebindMainTarget() {
-        net.vulkanmod.vulkan.pass.DefaultMainPass mainPass =
-                (net.vulkanmod.vulkan.pass.DefaultMainPass) Renderer.getInstance().getMainPass();
+        // Use the MainPass interface, not the concrete DefaultMainPass: shader mods
+        // (e.g. Beryl) swap in their own MainPass impl (net.beryl.render.ShaderMainPass),
+        // and rebindMainTarget() is declared on the interface. Hard-casting to
+        // DefaultMainPass threw ClassCastException every frame under Beryl → DH composite
+        // aborted → no LODs. VM 0.4.2's aux-field fixup below still needs the concrete
+        // type, but that path is pre-1.21.1 only (Field.get accepts the interface ref).
+        net.vulkanmod.vulkan.pass.MainPass mainPass = Renderer.getInstance().getMainPass();
         mainPass.rebindMainTarget();
 
         #if MC_VER < MC_1_21_1
@@ -556,6 +561,45 @@ public final class Compat {
         return dyn != null ? dyn.getId() : -1;
     }
     #endif
+
+    // ---- DH lightmap-wrapper validation gate (DH 3.2.0-b) ----
+    // DH gates LOD rendering behind RenderParams.getValidationErrorMessage(), which returns
+    // "No Lightmap Loaded" unless IMinecraftRenderWrapper.getLightmapWrapper(level) != null.
+    // That wrapper is normally registered by DH's MixinLightTexture → MinecraftRenderWrapper
+    // .updateLightmap() (which computeIfAbsent-creates the LightMapWrapper). Under VulkanMod that
+    // hook never produces a registered wrapper (VM doesn't drive MC's LightTexture the vanilla
+    // way), so DH refuses to draw LODs. We register the wrapper ourselves via the GL-free
+    // setLightmapId(int) path: MinecraftRenderWrapper.setLightmapId computeIfAbsent-creates+stores
+    // the wrapper, and LightMapWrapper.setLightmapId is a pure field setter (no GL). The bridge
+    // feeds the actual lightmap to the Vulkan renderer separately (getLightmapVulkanImage), so this
+    // wrapper is only a validation token. Must run on the render thread (client level present) or
+    // setLightmapId early-returns. setLightmapId is not on IMinecraftRenderWrapper and the concrete
+    // class name is loader-suffixed (_fabric/_neoforge) → resolve reflectively.
+    private static java.lang.reflect.Method dhSetLightmapIdMethod;
+    private static boolean dhSetLightmapIdResolved = false;
+
+    public static void ensureDhLightmapWrapperRegistered() {
+        try {
+            Object renderWrapper = com.seibel.distanthorizons.core.dependencyInjection.SingletonInjector.INSTANCE
+                    .get(com.seibel.distanthorizons.core.wrapperInterfaces.minecraft.IMinecraftRenderWrapper.class);
+            if (renderWrapper == null) return;
+            if (!dhSetLightmapIdResolved) {
+                dhSetLightmapIdResolved = true;
+                try {
+                    dhSetLightmapIdMethod = renderWrapper.getClass().getMethod("setLightmapId", int.class);
+                    dhSetLightmapIdMethod.setAccessible(true);
+                } catch (NoSuchMethodException ignored) { }
+            }
+            if (dhSetLightmapIdMethod == null) return;
+            int glId = 0;
+            #if MC_VER < MC_1_21_5
+            try { glId = Math.max(getLightmapGlId(), 0); } catch (Exception ignored) { }
+            #endif
+            dhSetLightmapIdMethod.invoke(renderWrapper, glId);
+        } catch (Exception ignored) {
+            // best-effort: never let validation-registration break the frame
+        }
+    }
 
     // ========================= //
     // Config value scaling //

--- a/vulkan/src/main/java/com/braffolk/dhvulkan/core/DhConfigHelper.java
+++ b/vulkan/src/main/java/com/braffolk/dhvulkan/core/DhConfigHelper.java
@@ -80,7 +80,7 @@ public final class DhConfigHelper {
     // =================== //
 
     public static boolean ssaoEnabled() {
-        return Config.Client.Advanced.Graphics.Ssao.enableSsao.get();
+        return Config.Client.Advanced.Graphics.enableSsao.get();
     }
 
     // =================== //

--- a/vulkan/src/main/java/com/braffolk/dhvulkan/core/VulkanBackend.java
+++ b/vulkan/src/main/java/com/braffolk/dhvulkan/core/VulkanBackend.java
@@ -2,7 +2,7 @@ package com.braffolk.dhvulkan.core;
 
 import com.braffolk.dhvulkan.core.data.RenderUniforms;
 import com.braffolk.dhvulkan.core.data.VkVertexData;
-import com.seibel.distanthorizons.core.util.math.Vec3f;
+import com.seibel.distanthorizons.core.util.math.DhVec3f;
 
 /**
  * Central rendering interface for the Vulkan backend.
@@ -28,7 +28,7 @@ public interface VulkanBackend {
      * Set the per-buffer model offset uniform.
      * Called once per LOD section, before drawing its VBOs.
      */
-    void setModelOffset(Vec3f modelOffset);
+    void setModelOffset(DhVec3f modelOffset);
 
     /**
      * Draw a vertex buffer. Called per-VBO in the render loop.

--- a/vulkan/src/main/java/com/braffolk/dhvulkan/core/VulkanCloudRenderer.java
+++ b/vulkan/src/main/java/com/braffolk/dhvulkan/core/VulkanCloudRenderer.java
@@ -4,7 +4,7 @@ import com.braffolk.dhvulkan.compat.Compat;
 import com.seibel.distanthorizons.core.config.Config;
 import com.seibel.distanthorizons.core.dependencyInjection.SingletonInjector;
 import com.seibel.distanthorizons.core.wrapperInterfaces.minecraft.IMinecraftRenderWrapper;
-import com.seibel.distanthorizons.core.util.math.Mat4f;
+import com.seibel.distanthorizons.core.util.math.DhMat4f;
 import net.minecraft.client.CloudStatus;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.multiplayer.ClientLevel;
@@ -99,7 +99,7 @@ public class VulkanCloudRenderer {
         return !this.reflectionFailed;
     }
 
-    public void renderIfEnabled(float partialTicks, Mat4f mcProjection, Mat4f mcModelView) {
+    public void renderIfEnabled(float partialTicks, DhMat4f mcProjection, DhMat4f mcModelView) {
         // Periodic config check
         if (--this.configRefreshCounter <= 0) {
             this.configRefreshCounter = CONFIG_REFRESH_INTERVAL;
@@ -141,7 +141,7 @@ public class VulkanCloudRenderer {
     }
 
     private void renderClouds(ClientLevel level, Minecraft mc, int cloudHeight,
-            float partialTicks, Mat4f mcProjection, Mat4f mcModelView) throws Throwable {
+            float partialTicks, DhMat4f mcProjection, DhMat4f mcModelView) throws Throwable {
         if (!mcRenderResolved) {
             MC_RENDER = SingletonInjector.INSTANCE.get(IMinecraftRenderWrapper.class);
             mcRenderResolved = true;
@@ -506,8 +506,8 @@ public class VulkanCloudRenderer {
         this.needsRebuild = true;
     }
 
-    /** Copy DH Mat4f into a reusable JOML Matrix4f (column-major). */
-    private static void copyToJoml(Mat4f src, Matrix4f dst) {
+    /** Copy DH DhMat4f into a reusable JOML Matrix4f (column-major). */
+    private static void copyToJoml(DhMat4f src, Matrix4f dst) {
         dst.set(src.m00, src.m10, src.m20, src.m30,
                 src.m01, src.m11, src.m21, src.m31,
                 src.m02, src.m12, src.m22, src.m32,

--- a/vulkan/src/main/java/com/braffolk/dhvulkan/core/VulkanRenderContext.java
+++ b/vulkan/src/main/java/com/braffolk/dhvulkan/core/VulkanRenderContext.java
@@ -12,9 +12,8 @@ import com.mojang.blaze3d.vertex.VertexFormat;
 import com.mojang.blaze3d.vertex.VertexFormatElement;
 import com.seibel.distanthorizons.core.logging.DhLogger;
 import com.seibel.distanthorizons.core.logging.DhLoggerBuilder;
-import com.seibel.distanthorizons.core.render.glObject.GLProxy;
-import com.seibel.distanthorizons.core.util.math.Mat4f;
-import com.seibel.distanthorizons.core.util.math.Vec3f;
+import com.seibel.distanthorizons.core.util.math.DhMat4f;
+import com.seibel.distanthorizons.core.util.math.DhVec3f;
 import net.vulkanmod.vulkan.Drawer;
 import net.vulkanmod.vulkan.Renderer;
 import net.vulkanmod.vulkan.shader.GraphicsPipeline;
@@ -157,7 +156,7 @@ public class VulkanRenderContext {
         }
 
         Pipeline.Builder builder = new Pipeline.Builder(DH_TERRAIN_FORMAT);
-        builder.compileShaders("dh_terrain", vertSource, fragSource);
+        com.braffolk.dhvulkan.compat.Compat.compilePipelineShaders(builder, "dh_terrain", vertSource, fragSource);
 
         // UBOs and samplers
         List<UBO> ubos = new ArrayList<>();
@@ -203,7 +202,7 @@ public class VulkanRenderContext {
         // Binding 1: LightMap sampler
         // VulkanMod hardcodes lightmap at texture slot 2 (see
         // VTextureSelector.setLightTexture())
-        imageDescriptors.add(new ImageDescriptor(1, "sampler2D", "uLightMap", 2));
+        imageDescriptors.add(com.braffolk.dhvulkan.compat.Compat.createImageDescriptor(1, "sampler2D", "uLightMap", 2));
 
         builder.setUniforms(ubos, imageDescriptors);
 
@@ -232,7 +231,7 @@ public class VulkanRenderContext {
     // ===================//
 
     /** Write a mat4 uniform value (column-major for std140 layout) */
-    public void setUniformMat4(String name, Mat4f matrix) {
+    public void setUniformMat4(String name, DhMat4f matrix) {
         MappedBuffer mb = this.uniformBuffers.get(name);
         if (mb == null)
             return;
@@ -260,7 +259,7 @@ public class VulkanRenderContext {
     }
 
     /** Write a vec3 uniform value */
-    public void setUniformVec3f(String name, Vec3f value) {
+    public void setUniformVec3f(String name, DhVec3f value) {
         MappedBuffer mb = this.uniformBuffers.get(name);
         if (mb == null)
             return;
@@ -274,7 +273,7 @@ public class VulkanRenderContext {
      * Write model offset directly (hot path, ~200× per frame).
      * Uses direct field reference — no HashMap lookup.
      */
-    public void setModelOffset(Vec3f value) {
+    public void setModelOffset(DhVec3f value) {
         this.modelOffsetBuffer.putFloat(0, value.x);
         this.modelOffsetBuffer.putFloat(4, value.y);
         this.modelOffsetBuffer.putFloat(8, value.z);

--- a/vulkan/src/main/java/com/braffolk/dhvulkan/core/VulkanRenderEngine.java
+++ b/vulkan/src/main/java/com/braffolk/dhvulkan/core/VulkanRenderEngine.java
@@ -236,7 +236,10 @@ public class VulkanRenderEngine implements VulkanBackend {
             return;
         }
 
-        // Bind MC's lightmap texture
+        // Bind MC's lightmap texture. (The DH lightmap-wrapper *registration* that opens
+        // DH's render-validation gate happens earlier and ungated, at renderLevel HEAD in
+        // MixinLevelRenderer — doing it here would be too late, since the gate skips this
+        // whole render path until the wrapper exists. Here we only bind the actual texture.)
         try {
             VulkanImage lightmapImage = Compat.getLightmapVulkanImage();
             if (lightmapImage != null) {

--- a/vulkan/src/main/java/com/braffolk/dhvulkan/core/VulkanRenderEngine.java
+++ b/vulkan/src/main/java/com/braffolk/dhvulkan/core/VulkanRenderEngine.java
@@ -17,8 +17,8 @@ import com.braffolk.dhvulkan.core.pipeline.DhFogPipeline;
 import com.braffolk.dhvulkan.core.pipeline.DhSsaoPipeline;
 import com.seibel.distanthorizons.core.config.Config;
 import com.seibel.distanthorizons.core.config.types.enums.EConfigEntryAppearance;
-import com.seibel.distanthorizons.core.util.math.Mat4f;
-import com.seibel.distanthorizons.core.util.math.Vec3f;
+import com.seibel.distanthorizons.core.util.math.DhMat4f;
+import com.seibel.distanthorizons.core.util.math.DhVec3f;
 import net.minecraft.client.Minecraft;
 import net.vulkanmod.vulkan.Renderer;
 import net.vulkanmod.vulkan.VRenderSystem;
@@ -44,11 +44,11 @@ import java.util.concurrent.ConcurrentLinkedQueue;
  */
 public class VulkanRenderEngine implements VulkanBackend {
     private static final Logger LOGGER = LogManager.getLogger("DH-VulkanEngine");
-    private static final Vec3f VEC3F_ZERO = new Vec3f(0, 0, 0);
+    private static final DhVec3f VEC3F_ZERO = new DhVec3f(0, 0, 0);
 
     // Pre-allocated reusable objects to avoid per-frame heap allocations
-    private final Mat4f tempCombinedMatrix = new Mat4f();
-    private final Mat4f tempInvProj = new Mat4f();
+    private final DhMat4f tempCombinedMatrix = new DhMat4f();
+    private final DhMat4f tempInvProj = new DhMat4f();
     private final float[] tempInvProjArray = new float[16];
     private final float[] tempMcProjArray = new float[16];
     private final float[] tempInvMcMvmProjArray = new float[16];
@@ -339,7 +339,7 @@ public class VulkanRenderEngine implements VulkanBackend {
     }
 
     @Override
-    public void setModelOffset(Vec3f modelOffset) {
+    public void setModelOffset(DhVec3f modelOffset) {
         if (this.initFailed)
             return;
         this.renderContext.setModelOffset(modelOffset);
@@ -771,12 +771,11 @@ public class VulkanRenderEngine implements VulkanBackend {
         Config.Client.Advanced.Debugging.DebugWireframe.showWorldGenQueue.setApiValue(false);
         Config.Client.Advanced.Debugging.DebugWireframe.showNetworkSyncOnLoadQueue.setApiValue(false);
         Config.Client.Advanced.Debugging.DebugWireframe.showRenderSectionStatus.setApiValue(false);
-        Config.Client.Advanced.Debugging.DebugWireframe.showRenderSectionToggling.setApiValue(false);
         Config.Client.Advanced.Debugging.DebugWireframe.showQuadTreeRenderStatus.setApiValue(false);
         Config.Client.Advanced.Debugging.DebugWireframe.showFullDataUpdateStatus.setApiValue(false);
 
-        Config.Client.Advanced.Graphics.GenericRendering.enableInstancedRendering
-                .setAppearance(EConfigEntryAppearance.ONLY_IN_FILE);
+        // NOTE: DH 3.2.0-b removed GenericRendering.enableInstancedRendering and
+        // OpenGl.glUploadMode / DebugWireframe.showRenderSectionToggling — dropped here.
         Config.Client.Advanced.Graphics.Fog.enableVanillaFog
                 .setAppearance(EConfigEntryAppearance.ONLY_IN_FILE);
         Config.Client.Advanced.Debugging.OpenGl.overrideVanillaGLLogger
@@ -784,8 +783,6 @@ public class VulkanRenderEngine implements VulkanBackend {
         Config.Client.Advanced.Debugging.OpenGl.onlyLogGlErrorsOnce
                 .setAppearance(EConfigEntryAppearance.ONLY_IN_FILE);
         Config.Client.Advanced.Debugging.OpenGl.glErrorHandlingMode
-                .setAppearance(EConfigEntryAppearance.ONLY_IN_FILE);
-        Config.Client.Advanced.Debugging.OpenGl.glUploadMode
                 .setAppearance(EConfigEntryAppearance.ONLY_IN_FILE);
     }
 }

--- a/vulkan/src/main/java/com/braffolk/dhvulkan/core/data/RenderUniforms.java
+++ b/vulkan/src/main/java/com/braffolk/dhvulkan/core/data/RenderUniforms.java
@@ -1,6 +1,7 @@
 package com.braffolk.dhvulkan.core.data;
 
-import com.seibel.distanthorizons.core.util.math.Mat4f;
+import com.seibel.distanthorizons.api.objects.math.DhApiMat4f;
+import com.seibel.distanthorizons.core.util.math.DhMat4f;
 
 /**
  * DH-agnostic uniform data for a single render frame.
@@ -9,13 +10,13 @@ import com.seibel.distanthorizons.core.util.math.Mat4f;
  */
 public class RenderUniforms {
     /** DH's projection matrix (extended near clip for high altitudes) */
-    public final Mat4f dhProjectionMatrix = new Mat4f();
+    public final DhMat4f dhProjectionMatrix = new DhMat4f();
 
     /** DH's model-view matrix */
-    public final Mat4f dhModelViewMatrix = new Mat4f();
+    public final DhMat4f dhModelViewMatrix = new DhMat4f();
 
     /** MC's projection matrix (for depth remapping in composite) */
-    public final Mat4f mcProjectionMatrix = new Mat4f();
+    public final DhMat4f mcProjectionMatrix = new DhMat4f();
 
     /** World Y offset for terrain rendering */
     public double worldYOffset;
@@ -26,8 +27,12 @@ public class RenderUniforms {
     /**
      * Set all fields from source matrices.
      * Callers should set worldYOffset and partialTicks directly.
+     *
+     * <p>Parameters are typed as the API base ({@link DhApiMat4f}) because
+     * DH 3.x's {@code RenderParams} exposes matrices as {@code DhApiMat4f};
+     * {@link DhMat4f#set(DhApiMat4f)} (inherited) copies the values.
      */
-    public void set(Mat4f dhProj, Mat4f dhModelView, Mat4f mcProj) {
+    public void set(DhApiMat4f dhProj, DhApiMat4f dhModelView, DhApiMat4f mcProj) {
         this.dhProjectionMatrix.set(dhProj);
         this.dhModelViewMatrix.set(dhModelView);
         this.mcProjectionMatrix.set(mcProj);

--- a/vulkan/src/main/java/com/braffolk/dhvulkan/core/pipeline/DhCompositePipeline.java
+++ b/vulkan/src/main/java/com/braffolk/dhvulkan/core/pipeline/DhCompositePipeline.java
@@ -138,7 +138,7 @@ public class DhCompositePipeline {
         String fragSource = readShaderResource("shaders/vulkan/dh_apply.frag");
 
         Pipeline.Builder builder = new Pipeline.Builder(QUAD_FORMAT);
-        builder.compileShaders("dh_composite", vertSource, fragSource);
+        com.braffolk.dhvulkan.compat.Compat.compilePipelineShaders(builder, "dh_composite", vertSource, fragSource);
 
         // UBO at binding 0: mat4 uInvProj (64 bytes) + int uDebugMode (4 bytes) + int
         // uUseMcDepth (4 bytes)
@@ -202,11 +202,11 @@ public class DhCompositePipeline {
 
         // Image descriptors — DH color/depth + SSAO/fog debug + MC depth
         List<ImageDescriptor> imageDescriptors = new ArrayList<>();
-        imageDescriptors.add(new ImageDescriptor(1, "sampler2D", "gDhColorTexture", DH_COLOR_TEXTURE_SLOT));
-        imageDescriptors.add(new ImageDescriptor(2, "sampler2D", "gDhDepthTexture", DH_DEPTH_TEXTURE_SLOT));
-        imageDescriptors.add(new ImageDescriptor(3, "sampler2D", "gSsaoTexture", DEBUG_SSAO_TEXTURE_SLOT));
-        imageDescriptors.add(new ImageDescriptor(4, "sampler2D", "gFogTexture", DEBUG_FOG_TEXTURE_SLOT));
-        imageDescriptors.add(new ImageDescriptor(5, "sampler2D", "gMcDepthTexture", MC_DEPTH_TEXTURE_SLOT));
+        imageDescriptors.add(com.braffolk.dhvulkan.compat.Compat.createImageDescriptor(1, "sampler2D", "gDhColorTexture", DH_COLOR_TEXTURE_SLOT));
+        imageDescriptors.add(com.braffolk.dhvulkan.compat.Compat.createImageDescriptor(2, "sampler2D", "gDhDepthTexture", DH_DEPTH_TEXTURE_SLOT));
+        imageDescriptors.add(com.braffolk.dhvulkan.compat.Compat.createImageDescriptor(3, "sampler2D", "gSsaoTexture", DEBUG_SSAO_TEXTURE_SLOT));
+        imageDescriptors.add(com.braffolk.dhvulkan.compat.Compat.createImageDescriptor(4, "sampler2D", "gFogTexture", DEBUG_FOG_TEXTURE_SLOT));
+        imageDescriptors.add(com.braffolk.dhvulkan.compat.Compat.createImageDescriptor(5, "sampler2D", "gMcDepthTexture", MC_DEPTH_TEXTURE_SLOT));
 
         builder.setUniforms(ubos, imageDescriptors);
         this.compositePipeline = builder.createGraphicsPipeline();

--- a/vulkan/src/main/java/com/braffolk/dhvulkan/core/pipeline/DhDepthReaderPipeline.java
+++ b/vulkan/src/main/java/com/braffolk/dhvulkan/core/pipeline/DhDepthReaderPipeline.java
@@ -118,7 +118,7 @@ public class DhDepthReaderPipeline {
         String fragSource = readShaderResource("shaders/vulkan/dh_depth_read.frag");
 
         Pipeline.Builder builder = new Pipeline.Builder(QUAD_FORMAT);
-        builder.compileShaders("dh_depth_read", vertSource, fragSource);
+        com.braffolk.dhvulkan.compat.Compat.compilePipelineShaders(builder, "dh_depth_read", vertSource, fragSource);
 
         List<UBO> ubos = new ArrayList<>();
         AlignedStruct.Builder uboBuilder = new AlignedStruct.Builder();
@@ -135,7 +135,7 @@ public class DhDepthReaderPipeline {
         ubos.add(mainUbo);
 
         List<ImageDescriptor> imageDescriptors = new ArrayList<>();
-        imageDescriptors.add(new ImageDescriptor(1, "sampler2D", "gMcDepthTexture", MC_DEPTH_READ_SLOT));
+        imageDescriptors.add(com.braffolk.dhvulkan.compat.Compat.createImageDescriptor(1, "sampler2D", "gMcDepthTexture", MC_DEPTH_READ_SLOT));
         builder.setUniforms(ubos, imageDescriptors);
 
         this.pipeline = builder.createGraphicsPipeline();

--- a/vulkan/src/main/java/com/braffolk/dhvulkan/core/pipeline/DhFogPipeline.java
+++ b/vulkan/src/main/java/com/braffolk/dhvulkan/core/pipeline/DhFogPipeline.java
@@ -17,7 +17,7 @@ import com.braffolk.dhvulkan.core.DhConfigHelper;
 import com.seibel.distanthorizons.core.config.Config;
 import com.seibel.distanthorizons.core.dependencyInjection.SingletonInjector;
 import com.seibel.distanthorizons.core.util.LodUtil;
-import com.seibel.distanthorizons.core.util.math.Mat4f;
+import com.seibel.distanthorizons.core.util.math.DhMat4f;
 import com.seibel.distanthorizons.core.wrapperInterfaces.minecraft.IMinecraftClientWrapper;
 import com.seibel.distanthorizons.core.wrapperInterfaces.minecraft.IMinecraftRenderWrapper;
 import com.seibel.distanthorizons.api.enums.rendering.EDhApiFogColorMode;
@@ -120,8 +120,8 @@ public class DhFogPipeline {
     private boolean initialized = false;
 
     // Pre-allocated temp matrices to avoid per-frame heap allocations
-    private final Mat4f tempMvpMatrix = new Mat4f();
-    private final Mat4f tempInvMvpMatrix = new Mat4f();
+    private final DhMat4f tempMvpMatrix = new DhMat4f();
+    private final DhMat4f tempInvMvpMatrix = new DhMat4f();
 
     public void init(int width, int height) {
         if (this.initialized)
@@ -188,7 +188,7 @@ public class DhFogPipeline {
         String fragSource = readShaderResource("shaders/vulkan/dh_fog.frag");
 
         Pipeline.Builder builder = new Pipeline.Builder(QUAD_FORMAT);
-        builder.compileShaders("dh_fog_compute", vertSource, fragSource);
+        com.braffolk.dhvulkan.compat.Compat.compilePipelineShaders(builder, "dh_fog_compute", vertSource, fragSource);
 
         List<UBO> ubos = new ArrayList<>();
         AlignedStruct.Builder uboBuilder = new AlignedStruct.Builder();
@@ -236,7 +236,7 @@ public class DhFogPipeline {
         ubos.add(mainUbo);
 
         List<ImageDescriptor> imageDescriptors = new ArrayList<>();
-        imageDescriptors.add(new ImageDescriptor(1, "sampler2D", "uDepthMap", FOG_DEPTH_TEXTURE_SLOT));
+        imageDescriptors.add(com.braffolk.dhvulkan.compat.Compat.createImageDescriptor(1, "sampler2D", "uDepthMap", FOG_DEPTH_TEXTURE_SLOT));
 
         builder.setUniforms(ubos, imageDescriptors);
         this.fogComputePipeline = builder.createGraphicsPipeline();
@@ -252,7 +252,7 @@ public class DhFogPipeline {
         String fragSource = readShaderResource("shaders/vulkan/dh_fog_apply.frag");
 
         Pipeline.Builder builder = new Pipeline.Builder(QUAD_FORMAT);
-        builder.compileShaders("dh_fog_apply", vertSource, fragSource);
+        com.braffolk.dhvulkan.compat.Compat.compilePipelineShaders(builder, "dh_fog_apply", vertSource, fragSource);
 
         List<UBO> ubos = new ArrayList<>();
         AlignedStruct.Builder uboBuilder = new AlignedStruct.Builder();
@@ -263,8 +263,8 @@ public class DhFogPipeline {
         ubos.add(mainUbo);
 
         List<ImageDescriptor> imageDescriptors = new ArrayList<>();
-        imageDescriptors.add(new ImageDescriptor(1, "sampler2D", "uFogTexture", FOG_COLOR_TEXTURE_SLOT));
-        imageDescriptors.add(new ImageDescriptor(2, "sampler2D", "uDepthTexture", FOG_APPLY_DEPTH_TEXTURE_SLOT));
+        imageDescriptors.add(com.braffolk.dhvulkan.compat.Compat.createImageDescriptor(1, "sampler2D", "uFogTexture", FOG_COLOR_TEXTURE_SLOT));
+        imageDescriptors.add(com.braffolk.dhvulkan.compat.Compat.createImageDescriptor(2, "sampler2D", "uDepthTexture", FOG_APPLY_DEPTH_TEXTURE_SLOT));
 
         builder.setUniforms(ubos, imageDescriptors);
         this.fogApplyPipeline = builder.createGraphicsPipeline();
@@ -279,7 +279,7 @@ public class DhFogPipeline {
      * Execute fog pipeline: pass 1 (compute fog) + pass 2 (apply fog).
      * Must be called after SSAO but before composite.
      */
-    public void render(DhVulkanFramebuffer dhFramebuffer, Mat4f modelViewMatrix, Mat4f projectionMatrix,
+    public void render(DhVulkanFramebuffer dhFramebuffer, DhMat4f modelViewMatrix, DhMat4f projectionMatrix,
             float partialTicks) {
         if (!this.initialized)
             return;
@@ -527,7 +527,7 @@ public class DhFogPipeline {
         Compat.addUniformWithBuffer(builder, type, name, count, () -> mb);
     }
 
-    private void setUniformMat4(Map<String, MappedBuffer> uniforms, String name, Mat4f matrix) {
+    private void setUniformMat4(Map<String, MappedBuffer> uniforms, String name, DhMat4f matrix) {
         MappedBuffer mb = uniforms.get(name);
         if (mb == null)
             return;

--- a/vulkan/src/main/java/com/braffolk/dhvulkan/core/pipeline/DhSsaoPipeline.java
+++ b/vulkan/src/main/java/com/braffolk/dhvulkan/core/pipeline/DhSsaoPipeline.java
@@ -15,7 +15,7 @@ import com.mojang.blaze3d.vertex.VertexFormat;
 import com.mojang.blaze3d.vertex.VertexFormatElement;
 import com.seibel.distanthorizons.core.config.Config;
 import com.seibel.distanthorizons.core.util.RenderUtil;
-import com.seibel.distanthorizons.core.util.math.Mat4f;
+import com.seibel.distanthorizons.core.util.math.DhMat4f;
 import net.vulkanmod.vulkan.Renderer;
 import net.vulkanmod.vulkan.VRenderSystem;
 import net.vulkanmod.vulkan.framebuffer.Framebuffer;
@@ -108,7 +108,7 @@ public class DhSsaoPipeline {
     private boolean initialized = false;
 
     // Pre-allocated temp matrix to avoid per-frame heap allocation
-    private final Mat4f tempInvProj = new Mat4f();
+    private final DhMat4f tempInvProj = new DhMat4f();
 
     // [DH 2.4 COMPAT] RenderUtil.getFarClipPlaneDistanceInBlocks() returns int in
     // DH 2.4 but float in DH 3.0. JVM treats return type as part of the method
@@ -238,7 +238,7 @@ public class DhSsaoPipeline {
         String fragSource = readShaderResource("shaders/vulkan/dh_ssao.frag");
 
         Pipeline.Builder builder = new Pipeline.Builder(QUAD_FORMAT);
-        builder.compileShaders("dh_ssao_compute", vertSource, fragSource);
+        com.braffolk.dhvulkan.compat.Compat.compilePipelineShaders(builder, "dh_ssao_compute", vertSource, fragSource);
 
         // UBO at binding 0: SSAO parameters
         List<UBO> ubos = new ArrayList<>();
@@ -268,7 +268,7 @@ public class DhSsaoPipeline {
 
         // Image descriptor: DH depth at binding 1
         List<ImageDescriptor> imageDescriptors = new ArrayList<>();
-        imageDescriptors.add(new ImageDescriptor(1, "sampler2D", "uDepthMap", SSAO_DEPTH_TEXTURE_SLOT));
+        imageDescriptors.add(com.braffolk.dhvulkan.compat.Compat.createImageDescriptor(1, "sampler2D", "uDepthMap", SSAO_DEPTH_TEXTURE_SLOT));
 
         builder.setUniforms(ubos, imageDescriptors);
         this.ssaoComputePipeline = builder.createGraphicsPipeline();
@@ -284,7 +284,7 @@ public class DhSsaoPipeline {
         String fragSource = readShaderResource("shaders/vulkan/dh_ssao_apply.frag");
 
         Pipeline.Builder builder = new Pipeline.Builder(QUAD_FORMAT);
-        builder.compileShaders("dh_ssao_apply", vertSource, fragSource);
+        com.braffolk.dhvulkan.compat.Compat.compilePipelineShaders(builder, "dh_ssao_apply", vertSource, fragSource);
 
         // UBO at binding 0: blur parameters
         List<UBO> ubos = new ArrayList<>();
@@ -302,8 +302,8 @@ public class DhSsaoPipeline {
 
         // Image descriptors: raw SSAO at binding 1, DH depth at binding 2
         List<ImageDescriptor> imageDescriptors = new ArrayList<>();
-        imageDescriptors.add(new ImageDescriptor(1, "sampler2D", "gSSAOMap", SSAO_RAW_TEXTURE_SLOT));
-        imageDescriptors.add(new ImageDescriptor(2, "sampler2D", "gDepthMap", SSAO_APPLY_DEPTH_TEXTURE_SLOT));
+        imageDescriptors.add(com.braffolk.dhvulkan.compat.Compat.createImageDescriptor(1, "sampler2D", "gSSAOMap", SSAO_RAW_TEXTURE_SLOT));
+        imageDescriptors.add(com.braffolk.dhvulkan.compat.Compat.createImageDescriptor(2, "sampler2D", "gDepthMap", SSAO_APPLY_DEPTH_TEXTURE_SLOT));
 
         builder.setUniforms(ubos, imageDescriptors);
         this.ssaoApplyPipeline = builder.createGraphicsPipeline();
@@ -324,7 +324,7 @@ public class DhSsaoPipeline {
      *                         rendering
      * @param projectionMatrix DH's projection matrix for depth reconstruction
      */
-    public void render(DhVulkanFramebuffer dhFramebuffer, Mat4f projectionMatrix) {
+    public void render(DhVulkanFramebuffer dhFramebuffer, DhMat4f projectionMatrix) {
         if (!this.initialized) {
             return;
         }
@@ -526,7 +526,7 @@ public class DhSsaoPipeline {
         Compat.addUniformWithBuffer(builder, type, name, count, () -> mb);
     }
 
-    private void setUniformMat4(Map<String, MappedBuffer> uniforms, String name, Mat4f matrix) {
+    private void setUniformMat4(Map<String, MappedBuffer> uniforms, String name, DhMat4f matrix) {
         MappedBuffer mb = uniforms.get(name);
         if (mb == null)
             return;

--- a/vulkan/src/main/java/com/braffolk/dhvulkan/mixin/dh3/MixinDependencySetup.java
+++ b/vulkan/src/main/java/com/braffolk/dhvulkan/mixin/dh3/MixinDependencySetup.java
@@ -14,7 +14,11 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
  * By cancelling the original method and binding our VkRenderApiDefinition instead,
  * we ensure DH uses our Vulkan rendering pipeline.
  */
-@Mixin(targets = "loaderCommon.fabric.com.seibel.distanthorizons.common.wrappers.DependencySetup", remap = false)
+// DH 3.2.0-b dropped the `loaderCommon.fabric.` relocation prefix and now emits
+// per-loader classes with a `_fabric` / `_neoforge` suffix. Under Fabric the class
+// actually instantiated (and whose static setRenderingApiBindings() runs) is the
+// _fabric variant. See HANDOFF Open Issue #1.
+@Mixin(targets = "com.seibel.distanthorizons.common.wrappers.DependencySetup_fabric", remap = false)
 public class MixinDependencySetup {
 
     @Inject(method = "setRenderingApiBindings", at = @At("HEAD"), cancellable = true)

--- a/vulkan/src/main/java/com/braffolk/dhvulkan/mixin/shared/MixinLevelRenderer.java
+++ b/vulkan/src/main/java/com/braffolk/dhvulkan/mixin/shared/MixinLevelRenderer.java
@@ -48,6 +48,27 @@ public class MixinLevelRenderer {
     }
 
     /**
+     * Register DH's lightmap wrapper at the START of level rendering, BEFORE DH's own
+     * LOD render (and thus before ClientApi's RenderParams validation) fires later in
+     * this same renderLevel call.
+     *
+     * DH 3.2.0-b hard-gates LOD rendering: ClientApi skips rendering entirely when
+     * RenderParams.getValidationErrorMessage() != null, and it returns "No Lightmap Loaded"
+     * unless MinecraftRenderWrapper.getLightmapWrapper(level) is non-null. That wrapper is
+     * normally registered by DH's MixinLightTexture → updateLightmap(), which does not
+     * produce a registered wrapper under VulkanMod (VM overwrites/replaces MC's LightTexture
+     * drive). Registering from inside our render path is too late — the gate skips that path,
+     * so it never runs (chicken-and-egg). Doing it here (ungated, once per frame) opens the
+     * gate; the actual lightmap texture is still supplied to the Vulkan renderer separately
+     * via Compat.getLightmapVulkanImage(). GL-free (setLightmapId is a pure setter).
+     */
+    @Inject(method = "renderLevel", at = @At("HEAD"))
+    private void dhvulkan$registerLightmapWrapper(CallbackInfo ci) {
+        if (!Compat.isVulkanModActive()) return;
+        Compat.ensureDhLightmapWrapperRegistered();
+    }
+
+    /**
      * Phase 2: deferred composite at renderLevel @RETURN.
      * Fires AFTER terrain + weather + everything.
      * Uses GL_LEQUAL depth test so weather pixels (depth < 1.0) are preserved —

--- a/vulkan/src/main/java/com/braffolk/dhvulkan/mixin/shared/MixinLightMapWrapper.java
+++ b/vulkan/src/main/java/com/braffolk/dhvulkan/mixin/shared/MixinLightMapWrapper.java
@@ -17,7 +17,10 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
  * bind()/unbind() only exist in DH 2.4 (they call glBindTexture/glActiveTexture)
  * — marked require = 0 so the mixin doesn't fail when targeting DH 3.0.
  */
-@Mixin(targets = "loaderCommon.fabric.com.seibel.distanthorizons.common.wrappers.misc.LightMapWrapper", remap = false)
+// DH 3.2.0-b: `loaderCommon.fabric.` relocation prefix gone; class now carries a
+// `_fabric` suffix (see HANDOFF Open Issue #1). uploadLightmap/createLightmap still
+// exist on the _fabric variant; bind/unbind (DH 2.4 only) stay require=0.
+@Mixin(targets = "com.seibel.distanthorizons.common.wrappers.misc.LightMapWrapper_fabric", remap = false)
 public class MixinLightMapWrapper {
 
     @Inject(method = "uploadLightmap", at = @At("HEAD"), cancellable = true)

--- a/vulkan/src/main/resources/dh-vulkanmod.mixins.json
+++ b/vulkan/src/main/resources/dh-vulkanmod.mixins.json
@@ -4,12 +4,6 @@
     "compatibilityLevel": "JAVA_21",
     "plugin": "com.braffolk.dhvulkan.DhVulkanMixinPlugin",
     "client": [
-        "dh24.MixinGLProxy",
-        "dh24.MixinGLState",
-        "dh24.MixinGLBuffer",
-        "dh24.MixinGLVertexBuffer",
-        "dh24.MixinLodRenderer",
-        "dh24.MixinLodBufferContainer",
         "dh3.MixinDependencySetup",
         "shared.MixinLevelRenderer",
         "shared.MixinLightMapWrapper"


### PR DESCRIPTION
Ports the bridge to MC 1.21.1 against DH 3.2.0-b and VulkanMod 0.6.7. LODs render in game, verified.

Two commits.

### 1. The port

VulkanMod 0.6.7 and DH 3.2.0-b API drift, plus a 1.21.1-1.21.4 lightmap path: 1.21.5+ keeps the `GlTexture`/`getTextureView` route, while 1.21.1 reads the lightmap `DynamicTexture` GL id and feeds `VkGlTexture.getTexture` (reflected by TYPE so it survives intermediary remapping). Also cloud helpers for the older `Options`/`NativeImage`/`DimensionType` APIs, and the legacy DH 2.4 (dh24) module is excluded when no DH 2.x jar is present, so the DH 3.x path builds standalone.

### 2. DH 3.2.0-b runtime compat

Three things that only showed up by actually running it:

- **Mixin retarget.** 3.2.0-b dropped the `loaderCommon.fabric.` relocation prefix in favour of a `_fabric`/`_neoforge` class suffix, so `MixinDependencySetup` and `MixinLightMapWrapper` were silently not applying (target not found) and the Vulkan renderers never bound.
- **"No Lightmap Loaded" gate.** 3.2.0-b's `ClientApi` hard-skips rendering when `RenderParams` validation fails, and that validation requires a registered lightmap wrapper. DH's own `LightTexture` hook does not register one under VulkanMod, because VulkanMod overwrites MC's `LightTexture` drive. So the wrapper is registered here, GL free, at `renderLevel` HEAD. The real lightmap still reaches the Vulkan renderer via `Compat.getLightmapVulkanImage()`. Flagging this one as a workaround: the upstream-quality fix is to make DH's validation VulkanMod aware, and I am happy to rework it into that shape if you would prefer.
- **Beryl compat.** `Compat.rebindMainTarget()` hard-cast `getMainPass()` to the concrete `DefaultMainPass`, but Beryl swaps in its own `ShaderMainPass`, so it threw `ClassCastException` every frame and aborted composite/endFrame. Cast to the `MainPass` interface instead; both impls declare `rebindMainTarget()`.

### Not included

Beryl shading of LODs. This is based on vm.2, and vm.4/vm.5 carry the actual Beryl work, so that needs porting separately.
